### PR TITLE
Sieben Funde aus dem mosaic-Bericht

### DIFF
--- a/.github/scripts/build-site.sh
+++ b/.github/scripts/build-site.sh
@@ -8,6 +8,8 @@
 #
 # Ergebnis in _site/:
 #     index.html, docs.css, typstage.pdf     das Handbuch
+#     en.html, typstage-en.pdf               das englische Handbuch
+#     llms.txt                               eine Zeile je Kapitel, für Maschinen
 #     beispiele/*.html, beispiele/index.html die Decks zum Anklicken
 #
 # Warum ein fremdes Repo gebraucht wird: docs/docs.typ setzt auf
@@ -32,10 +34,32 @@ mkdir -p "$PAKETPFAD/schule/typstage"
 cp -R "$AGGREGAT/schuldocs" "$PAKETPFAD/schule/schuldocs"
 ln -s "$WURZEL" "$PAKETPFAD/schule/typstage/$VERSION"
 
-rm -rf "$ZIEL"
-mkdir -p "$ZIEL"
+# Begleitpakete dazu, falls sie danebenliegen. Das Handbuch zeigt ein Beispiel
+# mit @schule/typstage-geogebra, und der Beispielprüfer kann es nur übersetzen,
+# wenn das Paket im Paketpfad steht. Fehlt es, überspringt er es und sagt es.
+# Auf die `typst.toml` gesehen, nicht auf das Verzeichnis: im Aggregat ist ein
+# Begleitpaket ein Submodul, und ein Checkout ohne `submodules: true` legt sein
+# Verzeichnis leer an. Ein leerer Baum kopiert sich anstandslos und bringt den
+# Prüflauf dann an der fehlenden `typst.toml` zu Fall, statt übersprungen zu
+# werden.
+for begleiter in typstage-geogebra; do
+  if compgen -G "$AGGREGAT/$begleiter/*/typst.toml" > /dev/null; then
+    cp -R "$AGGREGAT/$begleiter" "$PAKETPFAD/schule/$begleiter"
+  fi
+done
+
 typst --version
 echo "=== typstage $VERSION ==="
+
+# --- Beispiele in den Handbüchern -------------------------------------------
+# Vor dem Satz, nicht danach: ein Beispiel, das nicht mehr übersetzt, soll den
+# Bau anhalten und nicht als hübsch gesetzter Fehler auf der Website landen.
+# Und vor dem Aufräumen von `_site`, damit ein Fehlschlag nicht auch noch die
+# vorhandene Fassung mitnimmt.
+python3 "$WURZEL/.github/scripts/pruefe-beispiele.py" --paketpfad "$PAKETPFAD"
+
+rm -rf "$ZIEL"
+mkdir -p "$ZIEL"
 
 # --- Handbuch (Website, Stilvorlage und PDF in einem Bündel-Lauf) ------------
 (
@@ -74,6 +98,11 @@ if [[ -f "$WURZEL/docs/manual-en.typ" ]]; then
   [[ -f "$ZIEL/en.html" ]] || { echo "FEHLER: englisches Handbuch ohne en.html" >&2; exit 1; }
   echo "  → Manual (en): en.html, typstage-en.pdf"
 fi
+
+# --- llms.txt ---------------------------------------------------------------
+# Aus den gebauten Seiten, nicht aus `docs/content.typ`: die Sprungmarken
+# vergibt schuldocs beim Setzen, und zweimal ausgerechnet driften sie auseinander.
+python3 "$WURZEL/.github/scripts/llms-txt.py" "$ZIEL"
 
 # --- Beispielpräsentationen -------------------------------------------------
 namen=()

--- a/.github/scripts/llms-txt.py
+++ b/.github/scripts/llms-txt.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# =============================================================================
+# llms-txt.py — llms.txt für die Website, aus den gebauten Handbüchern
+# =============================================================================
+# Aufruf nach dem Handbuchbau, aus dem Repo-Wurzelverzeichnis:
+#
+#     python3 .github/scripts/llms-txt.py _site
+#
+# Ergebnis: `_site/llms.txt`, eine Zeile je Kapitel, Titel und erster Satz,
+# beide Sprachen. Das Format ist llmstxt.org: eine Überschrift, ein Zitatblock
+# mit der Kurzbeschreibung, dann Listen aus Verweisen.
+#
+# Warum aus dem *gebauten* HTML und nicht aus `docs/content.typ`: die
+# Sprungmarken (`#die-erste-praesentation`) vergibt `schuldocs` beim Setzen,
+# mit eigenen Regeln für Umlaute. Würde diese Datei sie noch einmal ausrechnen,
+# hätte das Projekt zwei Fassungen derselben Regel, und die eine würde von der
+# anderen wegdriften — genau das, was die Datei verhindern soll. Aus dem HTML
+# gelesen kann eine Sprungmarke hier gar nicht falsch sein.
+# =============================================================================
+
+import html
+import os
+import re
+import sys
+import tomllib
+
+WURZEL = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+# <h2 id="…">Titel<a class="anker" …>#</a></h2> und der Absatz darunter.
+KAPITEL = re.compile(
+  r'<h2 id="([^"]+)">(.*?)(?:<a class="anker".*?</a>)?</h2>\s*<p>(.*?)</p>',
+  re.S)
+
+
+def text(roh):
+  """HTML-Schnipsel zu gewöhnlichem Text."""
+  return html.unescape(re.sub(r"<[^>]+>", "", roh)).strip()
+
+
+def erster_satz(absatz):
+  """Bis zum ersten Punkt, der wirklich einen Satz schließt. Auf ihn muss ein
+  Großbuchstabe folgen oder das Ende, damit „0.15" nicht trennt; und davor darf
+  kein einzeln stehender Buchstabe sein, damit „z. B." es auch nicht tut."""
+  t = " ".join(absatz.split())
+  treffer = re.search(r"(?<!\b[A-Za-zÄÖÜäöü])[.!?](?=\s+[A-ZÄÖÜ„\"]|$)", t)
+  return t[:treffer.end()] if treffer else t
+
+
+def kapitel(pfad):
+  roh = open(pfad, encoding="utf-8").read()
+  return [(marke, text(titel), erster_satz(text(absatz)))
+          for marke, titel, absatz in KAPITEL.findall(roh)]
+
+
+def haupt(ziel):
+  paket = tomllib.load(open(os.path.join(WURZEL, "typst.toml"), "rb"))["package"]
+  # Die Adresse der Seite steht nirgends eigens; sie folgt aus dem Repo.
+  nutzer, repo = paket["repository"].rstrip("/").split("/")[-2:]
+  basis = "https://%s.github.io/%s/" % (nutzer.lower(), repo)
+
+  seiten = [
+    ("Handbuch (Deutsch)", "index.html", ""),
+    ("Manual (English)", "en.html", "en.html"),
+  ]
+  zeilen = [
+    "# %s %s" % (paket["name"], paket["version"]),
+    "",
+    "> " + " ".join(paket["description"].split()),
+    "",
+    ("Zwei Handbücher aus einer Quelle, je eine Seite. Die Sprungmarken unten "
+     "führen in das jeweilige Kapitel; die PDF-Fassungen liegen unter "
+     "`typstage.pdf` und `typstage-en.pdf`."),
+  ]
+  gesamt = 0
+  for name, datei, anhang in seiten:
+    pfad = os.path.join(ziel, datei)
+    if not os.path.exists(pfad):
+      continue
+    zeilen += ["", "## " + name, ""]
+    for marke, titel, satz in kapitel(pfad):
+      zeilen.append("- [%s](%s%s#%s): %s" % (titel, basis, anhang, marke, satz))
+      gesamt += 1
+
+  zeilen += [
+    "",
+    "## Quelle",
+    "",
+    "- [Repository](%s): Paketquellen, Beispieldecks und der Seitenbau."
+    % paket["repository"],
+    "- [Beispiele](%sbeispiele/): die sechs Beispielpräsentationen, laufend im "
+    "Browser." % basis,
+    "",
+  ]
+  raus = os.path.join(ziel, "llms.txt")
+  open(raus, "w", encoding="utf-8").write("\n".join(zeilen))
+  print("  → llms.txt: %d Kapitel" % gesamt)
+  return 0 if gesamt else 1
+
+
+if __name__ == "__main__":
+  sys.exit(haupt(sys.argv[1] if len(sys.argv) > 1 else os.path.join(WURZEL, "_site")))

--- a/.github/scripts/pruefe-beispiele.py
+++ b/.github/scripts/pruefe-beispiele.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+# =============================================================================
+# pruefe-beispiele.py — jedes Codebeispiel der Handbücher gegen das echte Paket
+# =============================================================================
+# Aufruf aus dem Repo-Wurzelverzeichnis:
+#
+#     python3 .github/scripts/pruefe-beispiele.py
+#     python3 .github/scripts/pruefe-beispiele.py --leise   # nur die Bilanz
+#     python3 .github/scripts/pruefe-beispiele.py --paketpfad /pfad
+#
+# Rückgabewert 0, wenn alles hält, sonst 1. `--paketpfad` wird an typst als
+# `--package-path` durchgereicht, für Läufe außerhalb eines eingerichteten
+# Paketverzeichnisses; der Seitenbau gibt seinen eigenen mit.
+#
+# Warum es das gibt: die beiden Handbücher enthalten über tausend Zeilen
+# Beispielcode. Ohne diesen Lauf prüft sie niemand gegen die Quelle, und ein
+# Beispiel, das nach einer Umbenennung nicht mehr übersetzt, fällt erst dem
+# Leser auf. Der Lauf holt jeden ```typ-Block aus `docs/content.typ` und
+# `docs/content-en.typ`, setzt ihn in eine übersetzbare Hülle und ruft `typst`
+# darauf. Dazu kommt jede Datei unter `examples/`, die ein Handbuch mit
+# `read(…)` einbindet, statt sie abzuschreiben: die wird als ganze Datei
+# übersetzt.
+#
+# --- Was die Hülle leistet, und was nicht ------------------------------------
+# Die meisten Blöcke sind Bruchstücke: `#fit(wrap: false, meine-tabelle)` ist
+# keine Datei. Der Prüfer legt darum je nach Art des Blocks etwas darum:
+#
+#   ganz     der Block ist schon eine vollständige Datei (er importiert das
+#            Paket selbst) und wird unverändert übersetzt
+#   dokument Import davor; der Block bringt seine eigene Show-Regel mit
+#   folgen   Import und `#show: presentation.with()` davor; der Block ist eine
+#            oder mehrere Folien und fängt mit einer Überschrift an
+#   folie    Import, Show-Regel und eine Überschrift davor; der Block ist der
+#            Rumpf einer einzelnen Folie (die Vorgabe)
+#
+# Die Art wird geraten, und das Raten ist grob: Import im Block heißt „ganz",
+# eine Zeile, die mit `#show: presentation` oder `#show: bundle` anfängt, heißt
+# „dokument", eine Zeile, die mit `=` anfängt, heißt „folgen", sonst „folie".
+# Wo das Raten danebenliegt oder ein Block mehr braucht, steht im Handbuch eine
+# Prüfzeile darüber. Sie ist ein gewöhnlicher Typst-Kommentar, steht außerhalb
+# des Codeblocks und erscheint deshalb weder im PDF noch auf der Website:
+#
+#     // check: folie pre=tabelle
+#     #show-code[```typ
+#     #fit(wrap: false, meine-tabelle)
+#     ```]
+#
+# Eine Prüfzeile gilt für den nächsten ```typ-Block, der ihr folgt. Der
+# Schlüssel steht in beiden Handbüchern gleich, damit ein Prüfer genügt.
+#
+#     check: ganz | dokument | folgen | folie
+#     check: aus=<grund>          nicht übersetzen, Grund erscheint im Bericht
+#     ziel=bundle                 mit --format bundle statt --format html
+#     pre=<name>                  benannten Vorspann davorsetzen (siehe VORSPANN)
+#     davor                       den vorigen ```typ-Block desselben Handbuchs
+#                                 davorsetzen (für Beispiele, die auf einem
+#                                 `#let` aus dem Absatz darüber aufbauen)
+#     dateien=a.png,b.mp4         genannte Dateien als Platzhalter anlegen
+#     fehlt=2                     Zeile 2 des Blocks *muss* fehlschlagen; der
+#                                 Rest muss übersetzen. Für Gegenüberstellungen
+#                                 („so — nicht so"). Übersetzt sie plötzlich, ist
+#                                 das ein Fehler, kein Erfolg.
+#     weil=cannot stand inside    Woran sie fehlschlagen muss. Ohne diese Angabe
+#                                 zählt jeder Fehlschlag, auch ein Tippfehler
+#                                 oder eine vergessene Einbindung -- und dann
+#                                 besteht der Test aus dem falschen Grund. Der
+#                                 Text muss in der Meldung von `typst` vorkommen.
+#
+# Ein Beispiel, das ein Begleitpaket braucht, das im Paketpfad nicht liegt,
+# wird gemeldet und übersprungen, nicht als Fehler ausgegeben.
+#
+# Ehrlich gesagt, was das *nicht* prüft: ob das Beispiel das Richtige *zeigt*.
+# Der Lauf sagt „übersetzt" und „übersetzt nicht", mehr nicht. Er sieht die
+# Folie nicht an. Und ein Bruchstück wird in einer Hülle geprüft, nicht in der
+# Umgebung, aus der der Text es geschnitten hat.
+# =============================================================================
+
+import argparse
+import base64
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from concurrent.futures import ThreadPoolExecutor
+
+WURZEL = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+HANDBUECHER = ["docs/content.typ", "docs/content-en.typ"]
+IMPORT = '#import "@schule/typstage:0.1.0": *\n'
+
+# Namen, die die Handbücher als Platzhalter benutzen, ohne sie zu erklären —
+# „meine-tabelle" steht im Text für „irgendeine Tabelle". Der Prüfer muss
+# etwas darunter legen, sonst prüft er nur, dass ein Name fehlt.
+VORSPANN = {
+  "tabelle": (
+    "#let meine-tabelle = table(columns: 2, [Jahr], [Wert], [2024], [7])\n"
+    "#let my-table = meine-tabelle\n"
+  ),
+}
+
+# Ein 1x1-Pixel-PNG. `image()` liest die Datei beim Übersetzen, ein leerer
+# Platzhalter genügt ihr also nicht.
+PNG = base64.b64decode(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk"
+  "+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+)
+
+PAKET = re.compile(r'"@schule/([a-z0-9-]+):([0-9.]+)"')
+FENCE = re.compile(r"(`{3,})([a-zA-Z][a-zA-Z0-9]*)\s*$")
+PRUEFZEILE = re.compile(r"^\s*//\s*check:\s*(.+?)\s*$")
+LESEN = re.compile(r'read\(\s*"((?:\.\./)*examples/[^"]+\.typ)"\s*\)')
+
+
+def paketwurzeln(paketpfad):
+  """Wo Typst nach `@schule/...` sucht. Der Prüfer schaut selbst nach, damit er
+  ein fehlendes Begleitpaket melden kann, statt es als Fehler auszugeben."""
+  # `--package-path` ersetzt bei typst das Vorgabeverzeichnis, es kommt nicht
+  # dazu. Der Prüfer muss deshalb genauso schauen, sonst hält er ein Paket für
+  # vorhanden, das der Übersetzer nicht sieht.
+  if paketpfad:
+    return [paketpfad] if os.path.isdir(paketpfad) else []
+  wurzeln = []
+  daten = os.environ.get("XDG_DATA_HOME")
+  wurzeln += [
+    os.path.expanduser("~/Library/Application Support/typst/packages"),
+    os.path.join(daten, "typst", "packages") if daten
+    else os.path.expanduser("~/.local/share/typst/packages"),
+  ]
+  return [w for w in wurzeln if os.path.isdir(w)]
+
+
+def fehlende_pakete(quelle, wurzeln):
+  """Welche @schule-Pakete eines Blocks nirgends im Paketpfad liegen.
+
+  Gefragt wird nach der `typst.toml`, nicht nach dem Verzeichnis. Ein
+  Begleitpaket ist im Aggregat ein Submodul, und ein Checkout ohne
+  `submodules: true` legt sein Verzeichnis leer an. Auf das Verzeichnis zu
+  sehen hieße dort "vorhanden", der Block liefe los, und `typst` bräche an der
+  fehlenden `typst.toml` ab -- statt dass der Lauf ihn sauber überspringt.
+  Genau so ist der Seitenbau in der CI gestorben.
+  """
+  fehlt = []
+  for name, version in set(PAKET.findall(quelle)):
+    if not any(os.path.isfile(os.path.join(w, "schule", name, version, "typst.toml"))
+               for w in wurzeln):
+      fehlt.append("@schule/%s:%s" % (name, version))
+  return sorted(fehlt)
+
+
+def dedent(zeilen):
+  """Führende Leerzeichen abziehen, wie Typst es beim Setzen des Blocks tut."""
+  tiefe = min([len(z) - len(z.lstrip()) for z in zeilen if z.strip()] or [0])
+  return "\n".join(z[tiefe:] if z.strip() else "" for z in zeilen)
+
+
+def bloecke(pfad):
+  """Alle Codeblöcke einer Handbuchdatei, mit ihrer Prüfzeile."""
+  zeilen = open(pfad, encoding="utf-8").read().split("\n")
+  gefunden, offen, i = [], None, 0
+  while i < len(zeilen):
+    treffer = FENCE.search(zeilen[i])
+    if treffer:
+      zaun, sprache = treffer.group(1), treffer.group(2)
+      schluss = re.compile(r"^\s*" + zaun)
+      j, rumpf = i + 1, []
+      while j < len(zeilen) and not schluss.match(zeilen[j]):
+        rumpf.append(zeilen[j])
+        j += 1
+      gefunden.append({
+        "datei": pfad, "zeile": i + 1, "sprache": sprache,
+        "rumpf": dedent(rumpf), "regie": offen,
+      })
+      offen, i = None, j + 1
+      continue
+    p = PRUEFZEILE.match(zeilen[i])
+    if p:
+      offen = p.group(1)
+    i += 1
+  return gefunden
+
+
+def regie_lesen(text):
+  """Eine Prüfzeile in ein Wörterbuch übersetzen."""
+  r = {"art": None, "aus": None, "ziel": "html", "pre": [], "davor": False,
+       "dateien": [], "fehlt": [], "weil": None}
+  for wort in (text or "").split():
+    if wort in ("ganz", "dokument", "folgen", "folie", "argument"):
+      r["art"] = wort
+    elif wort == "davor":
+      r["davor"] = True
+    elif wort.startswith("aus="):
+      r["aus"] = wort[4:].replace("_", " ")
+    elif wort.startswith("ziel="):
+      r["ziel"] = wort[5:]
+    elif wort.startswith("pre="):
+      r["pre"] += wort[4:].split(",")
+    elif wort.startswith("dateien="):
+      r["dateien"] += wort[8:].split(",")
+    elif wort.startswith("fehlt="):
+      r["fehlt"] += [int(n) for n in wort[6:].split(",")]
+    elif wort.startswith("weil="):
+      r["weil"] = wort[5:].replace("_", " ")
+    else:
+      raise SystemExit("unbekanntes Wort in einer Prüfzeile: " + wort)
+  return r
+
+
+def art_raten(rumpf):
+  if re.search(r'^#import\s+"@schule/typstage', rumpf, re.M):
+    return "ganz"
+  if re.search(r"^#show:\s*(presentation|bundle)", rumpf, re.M):
+    return "dokument"
+  if re.search(r"^=+\s", rumpf, re.M):
+    return "folgen"
+  return "folie"
+
+
+def huelle(art, rumpf, vorspann):
+  if art == "ganz":
+    return rumpf
+  kopf = IMPORT + vorspann
+  if art == "dokument":
+    return kopf + rumpf
+  # Die Argumentschreibweise: `slide(..)` gibt ein Wörterbuch zurück und muss
+  # `presentation` als Argument erreichen. Unter einer Show-Regel steht es im
+  # Rumpf, und dort ist es nichts -- gemessen ergibt dieselbe Zeile so 0 Folien
+  # statt 1, fehlerfrei. Eine Hülle, in der ein Beispiel spurlos verschwindet,
+  # prüft nichts.
+  if art == "argument":
+    # Das führende `#` fällt weg: im Handbuch steht die Zeile als Aufruf im
+    # Fließtext, als Argument steht sie in Code, und dort ist `#` ungültig.
+    # Genau der Handgriff, den ein Leser beim Einsetzen macht.
+    ohne = "\n".join(z[1:] if z.startswith("#") else z
+                     for z in rumpf.split("\n"))
+    return kopf + "#presentation(\n" + ohne + ",\n)\n"
+  kopf += "#show: presentation.with()\n"
+  if art == "folgen":
+    return kopf + rumpf
+  return kopf + "== Beispiel\n" + rumpf
+
+
+def uebersetzen(quelle, ziel, dateien, paketpfad=None):
+  """Einmal `typst compile`. Gibt (geklappt, Meldung) zurück."""
+  with tempfile.TemporaryDirectory(dir=os.path.join(WURZEL, ".pruef-tmp")) as d:
+    datei = os.path.join(d, "beispiel.typ")
+    open(datei, "w", encoding="utf-8").write(quelle)
+    for name in dateien:
+      pfad = os.path.join(d, os.path.basename(name))
+      with open(pfad, "wb") as f:
+        f.write(PNG if name.lower().endswith((".png", ".jpg", ".jpeg")) else b"")
+    if ziel == "bundle":
+      befehl = ["typst", "compile", "--format", "bundle",
+                "--features", "bundle,html", "--root", WURZEL, datei, d]
+    else:
+      befehl = ["typst", "compile", "--format", "html", "--features", "html",
+                "--root", WURZEL, datei, os.path.join(d, "beispiel.html")]
+    if paketpfad:
+      befehl[2:2] = ["--package-path", paketpfad]
+    lauf = subprocess.run(befehl, capture_output=True, text=True)
+  meldung = "\n".join(
+    z for z in lauf.stderr.split("\n")
+    if z.strip() and not re.match(r"^\s*(warning: (html|bundle) export|= hint:)", z)
+  )
+  return lauf.returncode == 0, meldung
+
+
+def pruefen(auftrag):
+  block, voriger, paketpfad, wurzeln = auftrag
+  ort = "%s:%d" % (os.path.relpath(block["datei"], WURZEL), block["zeile"])
+  regie = regie_lesen(block["regie"])
+  if regie["aus"]:
+    return {"ort": ort, "stand": "aus", "grund": regie["aus"]}
+  art = regie["art"] or art_raten(block["rumpf"])
+  vorspann = "".join(VORSPANN[n] for n in regie["pre"])
+  if regie["davor"]:
+    if voriger is None:
+      return {"ort": ort, "stand": "fehler", "art": art,
+              "meldung": "`davor` verlangt einen Block darüber, es gibt keinen"}
+    vorspann += voriger + "\n"
+
+  # Ein Beispiel, das ein Begleitpaket braucht, das hier nicht liegt, wird
+  # gemeldet und übersprungen, nicht als Fehler ausgegeben. Wer nur typstage
+  # ausgecheckt hat, soll den Lauf trotzdem grün bekommen und dabei sehen,
+  # was ungeprüft blieb.
+  fehlt_paket = fehlende_pakete(block["rumpf"], wurzeln)
+  if fehlt_paket:
+    return {"ort": ort, "stand": "aus", "grund": "ohne " + ", ".join(fehlt_paket)}
+
+  zeilen = block["rumpf"].split("\n")
+  for n in regie["fehlt"]:
+    if not 1 <= n <= len(zeilen):
+      return {"ort": ort, "stand": "fehler", "art": art,
+              "meldung": "fehlt=%d, aber der Block hat nur %d Zeilen" % (n, len(zeilen))}
+
+  # Erst der Rest ohne die Zeilen, die fehlschlagen sollen: der muss übersetzen.
+  rest = "\n".join(z for i, z in enumerate(zeilen, 1) if i not in regie["fehlt"])
+  geklappt, meldung = uebersetzen(
+    huelle(art, rest, vorspann), regie["ziel"], regie["dateien"], paketpfad)
+  if not geklappt:
+    return {"ort": ort, "stand": "fehler", "art": art, "meldung": meldung}
+
+  # Dann jede einzelne dieser Zeilen für sich: die muss fehlschlagen.
+  for n in regie["fehlt"]:
+    geklappt, meldung = uebersetzen(
+      huelle(art, zeilen[n - 1], vorspann), regie["ziel"], regie["dateien"],
+      paketpfad)
+    if geklappt:
+      return {
+        "ort": ort, "stand": "fehler", "art": art,
+        "meldung": ("Zeile %d ist als „soll fehlschlagen\" geführt, übersetzt "
+                    "aber: %s" % (n, zeilen[n - 1].strip())),
+      }
+    # Und am richtigen Grund. Ein Fehlschlag an einem Tippfehler wäre ein
+    # bestandener Test aus dem falschen Grund, und das ist schlimmer als ein
+    # durchgefallener.
+    if regie["weil"] and regie["weil"] not in meldung:
+      return {
+        "ort": ort, "stand": "fehler", "art": art,
+        "meldung": ("Zeile %d schlägt fehl, aber nicht an „%s\": %s"
+                    % (n, regie["weil"], meldung.strip().splitlines()[0]
+                       if meldung.strip() else "(ohne Meldung)")),
+      }
+  return {"ort": ort, "stand": "gut", "art": art, "fehlt": len(regie["fehlt"])}
+
+
+def gelesene_dateien():
+  """Beispiele, die das Handbuch aus einer echten Datei liest, statt sie
+  abzuschreiben. Die werden als ganze Dateien übersetzt."""
+  raus = []
+  for name in HANDBUECHER:
+    pfad = os.path.join(WURZEL, name)
+    text = open(pfad, encoding="utf-8").read()
+    for treffer in sorted(set(LESEN.findall(text))):
+      ziel = os.path.normpath(os.path.join(os.path.dirname(pfad), treffer))
+      raus.append((name, treffer, ziel))
+  return raus
+
+
+def haupt():
+  s = argparse.ArgumentParser(add_help=True)
+  s.add_argument("--leise", action="store_true", help="nur die Bilanz ausgeben")
+  s.add_argument("--paketpfad", default=None,
+                 help="an typst durchgereicht (--package-path), für Läufe "
+                      "außerhalb eines eingerichteten Paketverzeichnisses")
+  args = s.parse_args()
+  wurzeln = paketwurzeln(args.paketpfad)
+
+  # Eigenes Wegwerfverzeichnis *innerhalb* der Paketwurzel, weil typst nur
+  # übersetzt, was unter --root liegt. Vorher leeren, falls ein abgebrochener
+  # Lauf etwas hat stehen lassen.
+  wegwerf = os.path.join(WURZEL, ".pruef-tmp")
+  shutil.rmtree(wegwerf, ignore_errors=True)
+  os.makedirs(wegwerf, exist_ok=True)
+  auftraege, ergebnisse = [], []
+  # Was nicht `typ` heißt, wird nicht geprüft -- und ein Block, der lautlos
+  # aus der Prüfung fällt, ist genau die Art, wie so ein Lauf über die Jahre
+  # stumpf wird. Deshalb werden die anderen Sprachen gezählt und am Ende
+  # genannt, und ein Zaun, der wie ein verschriebenes `typ` aussieht, ist ein
+  # Fehler: `typst` und `typc` sind keine Sprachen, die hier etwas zu suchen
+  # haben, wohl aber ein naheliegender Griff daneben.
+  andere, verschrieben = {}, []
+  for name in HANDBUECHER:
+    voriger = None
+    for block in bloecke(os.path.join(WURZEL, name)):
+      if block["sprache"] != "typ":
+        if block["sprache"] in ("typst", "typc", "typ:"):
+          verschrieben.append("%s:%d hat ```%s -- gemeint ist ```typ"
+                              % (block["datei"], block["zeile"], block["sprache"]))
+        andere[block["sprache"]] = andere.get(block["sprache"], 0) + 1
+        continue
+      auftraege.append((block, voriger, args.paketpfad, wurzeln))
+      voriger = block["rumpf"]
+  if verschrieben:
+    for z in verschrieben:
+      print("--- FEHLER " + z)
+    return 1
+
+  with ThreadPoolExecutor(max_workers=max(4, os.cpu_count() or 4)) as pool:
+    ergebnisse = list(pool.map(pruefen, auftraege))
+
+  # Die aus echten Dateien gelesenen Beispiele.
+  gelesen = gelesene_dateien()
+  for handbuch, ref, ziel in gelesen:
+    ort = "%s → %s" % (handbuch, ref)
+    if not os.path.exists(ziel):
+      ergebnisse.append({"ort": ort, "stand": "fehler", "art": "ganz",
+                         "meldung": "die gelesene Datei gibt es nicht: " + ziel})
+      continue
+    quelle = open(ziel, encoding="utf-8").read()
+    fehlt_paket = fehlende_pakete(quelle, wurzeln)
+    if fehlt_paket:
+      ergebnisse.append({"ort": ort, "stand": "aus",
+                         "grund": "ohne " + ", ".join(fehlt_paket)})
+      continue
+    geklappt, meldung = uebersetzen(quelle, "html", [], args.paketpfad)
+    ergebnisse.append({"ort": ort, "art": "gelesen",
+                       "stand": "gut" if geklappt else "fehler",
+                       "meldung": meldung})
+
+  gut = [e for e in ergebnisse if e["stand"] == "gut"]
+  aus = [e for e in ergebnisse if e["stand"] == "aus"]
+  fehler = [e for e in ergebnisse if e["stand"] == "fehler"]
+  gegen = sum(e.get("fehlt", 0) for e in gut)
+
+  if not args.leise:
+    for e in aus:
+      print("  übersprungen  %-34s %s" % (e["ort"], e["grund"]))
+  for e in fehler:
+    print("\n--- FEHLER %s  [%s]" % (e["ort"], e.get("art", "?")))
+    print("\n".join("    " + z for z in e["meldung"].split("\n")[:14]))
+  if andere:
+    print("nicht geprüft, weil andere Zaunsprache: "
+          + ", ".join("%dx %s" % (n, k) for k, n in sorted(andere.items())))
+  print("\nBeispiele: %d übersetzt · %d als „soll fehlschlagen\" geprüft · "
+        "%d übersprungen · %d Fehler"
+        % (len(gut), gegen, len(aus), len(fehler)))
+  shutil.rmtree(wegwerf, ignore_errors=True)
+  return 1 if fehler else 0
+
+
+if __name__ == "__main__":
+  sys.exit(haupt())

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ _site/
 # Sicherungskopien beim Umbauen
 *.vor-*
 *.sicherung
+
+# Wegwerfdateien von .github/scripts/pruefe-beispiele.py
+.pruef-tmp/

--- a/README.md
+++ b/README.md
@@ -114,9 +114,11 @@ written.
 | `overflow:` | a checking pass, off by default: `"error"` builds the deck and then names every slide whose body runs over its room, with the step; `"record"` files the same as queryable metadata |
 | `transition`, `speaker-note` | how this slide comes in, and what only you see |
 | `themes`, `theme` | the five built-in looks, and the builder behind them |
+| `palettes`, `palette:`, `invert` | colour separately from design: five bundled palettes that compose with every theme, a partial override on `presentation`, and one slide set in the palette turned around |
+| `contrast`, `palette-report` | the WCAG contrast of two colours, and the six pairs the bundled palettes are held to |
 | `video`, `embed`, `flipbook` | media, arbitrary web content in a sandboxed frame, and animation drawn frame by frame by Typst |
 | `bridge-job`, `bridge-targets` | send step jobs into an embedded document, which is how companion packages drive an applet |
-| `slide-width`, `slide-height`, `slide-margin`, `dark`, `accent`, `paper`, `muted` | the defaults behind `width:` and the palette |
+| `slide-width`, `slide-height`, `slide-margin`, `dark`, `accent`, `paper`, `muted` | the defaults behind `width:`, and the four colour constants of the default look |
 | `runtime-version`, `runtime-files` | the CSS and the JS, for `assets: "split"` and for CDNs |
 
 Every one of them is documented in full, with examples, in the manual
@@ -132,6 +134,7 @@ single slide, each of them a true reversal when you page backwards. Entrances
 ```typ
 #show: presentation.with(theme: themes.night)
 #show: presentation.with(theme: themes.lesson + (accent: blue))
+#show: presentation.with(theme: themes.lesson, palette: palettes.dark)
 ```
 
 ![The same slide in the five built-in themes: default, lesson, night, plain, editorial](assets/themes.png)
@@ -145,6 +148,37 @@ textbook does, a tinted panel with its label inside rather than a coloured bar
 above. Only the title slide
 and the section slide are functions in it: they are whole pictures, not
 variations of one another.
+
+## Palettes and the contrast contract
+
+Colour is a thing of its own. `palette:` takes a flat dictionary over the eight
+colour entries and overwrites *partially*, so `palette: (accent: blue)` moves
+the accent alone. Five ship with the package, `light`, `mono`, `textbook`,
+`parchment` and `dark`, and each composes with each theme: darkness is a
+palette rather than a design, and `themes.lesson` under `palettes.dark` is
+still the lesson design, only dark. `themes.night` stays a theme all the same,
+because its cyan is tuned to its own ground -- it measures 9.77 to 1 there and
+1.59 to 1 on the ground an inverted slide puts behind it.
+
+Reading `themes.X.title-fill` or `.rule-fill` no longer gives a colour: they
+are now functions of the palette, or `none` for "the accent". Writing them
+(`themes.X + (title-fill: red)`) works as before.
+
+`invert` sets one slide in the palette turned around, for the slide that
+carries a single number: the ground becomes the palette's text colour and the
+text becomes its ground, `muted`, `border` and `surface` are mixed from those
+two, and `strong` and `accent` carry over unchanged. The running head, the
+footer and the progress bar follow.
+
+The five bundled palettes, and their inverted forms with them, are held to a
+measured contrast contract: real WCAG 2 arithmetic over six pairs, enforced by
+an assertion that runs when the package is loaded. **Your own palettes face no
+such gate**, and neither do the bundled *themes*: run over those, the contract
+finds `muted` at 4.25 in `lesson`, at 3.35 in `plain` and at 3.51 in
+`editorial` against the 4.5 body text wants, `accent` at 2.84 in `editorial`
+against 3.0, and `accent` on `ink` at 1.59 in `night` and 1.27 in `plain`. Only
+`themes.default` passes all six. Those colours were left alone; the manual says
+why, and `palette-report(…)` hands the same measurement back for any palette.
 
 ## In the browser
 
@@ -317,6 +351,10 @@ else, no Node, no bundler.
 - **Five themes, not a theme ecosystem.** They differ in colour, type and the
   shape of header, footer and progress bar, not in slide layouts. Anything
   further is a dictionary entry, a `style:` wrapper, or plain Typst.
+- **The contrast contract binds the bundled palettes only.** A palette written
+  in a deck is never checked and never recoloured, and no colour is inferred
+  from the lightness of another: a muted sage such as `#aebdb3` reads as
+  "light" to a luminance rule, yet white on it measures 1.96 to 1.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ written.
 | `card`, `callout`, `side-by-side`, `tiles`, `statement` | layouts inside a slide; `tiles` staggers itself, and `side-by-side(equal: true)` makes its columns the same height |
 | `fit` | scales one block down to the room it has, for a wide table or a generated chart; no reveal may sit inside it |
 | `overflow:` | a checking pass, off by default: `"error"` builds the deck and then names every slide whose body runs over its room, with the step; `"record"` files the same as queryable metadata |
+| `info` | what the deck knows about itself: title, slide and step number, section — for a footer or a running head of your own |
 | `transition`, `speaker-note` | how this slide comes in, and what only you see |
 | `themes`, `theme` | the five built-in looks, and the builder behind them |
 | `palettes`, `palette:`, `invert` | colour separately from design: five bundled palettes that compose with every theme, a partial override on `presentation`, and one slide set in the palette turned around |

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ written.
 | `morph`, `pin` | magic move across slides; `pin` names a glyph so the pairing follows the name rather than the shape |
 | `card`, `callout`, `side-by-side`, `tiles`, `statement` | layouts inside a slide; `tiles` staggers itself, and `side-by-side(equal: true)` makes its columns the same height |
 | `fit` | scales one block down to the room it has, for a wide table or a generated chart; no reveal may sit inside it |
+| `overflow:` | a checking pass, off by default: `"error"` builds the deck and then names every slide whose body runs over its room, with the step; `"record"` files the same as queryable metadata |
 | `transition`, `speaker-note` | how this slide comes in, and what only you see |
 | `themes`, `theme` | the five built-in looks, and the builder behind them |
 | `video`, `embed`, `flipbook` | media, arbitrary web content in a sandboxed frame, and animation drawn frame by frame by Typst |

--- a/README.md
+++ b/README.md
@@ -374,9 +374,37 @@ One run gives the printed manual, the website and its stylesheet:
 typst compile docs/docs.typ build --format bundle --features bundle,html --root .
 ```
 
+The site build also writes [llms.txt](https://loewe1000.github.io/typstage/llms.txt),
+one line per chapter with its title and first sentence, in both languages. It is
+generated from the built pages, so its anchors cannot go stale.
+
 `example.typ` in the repository is a deck that exercises everything: reveals,
 magic move, an embedded live canvas, a CeTZ flipbook. It is not shipped with
 the package, so build it from a clone.
+
+### The examples in the manual are compiled
+
+Every `typ` listing in both manuals is compiled against the real package before
+the site is built, so a renamed function or a changed signature cannot leave a
+listing behind:
+
+```bash
+python3 .github/scripts/pruefe-beispiele.py
+```
+
+Most listings are fragments rather than whole files, so the run wraps each one
+in a deck and a slide before compiling it. That is what it checks: that the
+code compiles in such a wrapper, not that the slide looks right. Where a
+fragment needs more than the wrapper gives it, a `// check:` line above the
+listing says so; the header of the script lists the words it takes. Listings
+that show what does *not* work are marked, have to keep failing, and say what
+they have to fail at -- a listing that breaks for some other reason is a failed
+check, not a passed one. The build runs this first and stops on it.
+
+What it does not reach: the prose beside a listing, listings in `bash` or
+`json` (it names how many it left alone), the paged output, and anything that
+compiles without doing what it claims -- a show rule on a label that no longer
+exists still compiles.
 
 ## Companion packages
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ written.
 | `presentation` | builds the deck: slides as arguments, or a show-rule body split at its headings |
 | `bundle` | writes talk, slide set and handout in a single compile |
 | `slide`, `section`, `title-slide` | the three kinds of slide |
-| `anim`, `stagger`, `pause`, `alternatives` | reveal one thing, a series of things, everything after this point, one thing after another in the same place |
+| `anim`, `stagger`, `pause`, `alternatives` | reveal one thing, a series of things, everything after this point, one thing after another in the same place; `anim(after: "dimmed")` lets a point stay muted once its range is over, and `stagger(dim: true)` walks a list that way, the current point lit and the earlier ones quiet |
 | `morph`, `pin` | magic move across slides; `pin` names a glyph so the pairing follows the name rather than the shape |
 | `card`, `callout`, `side-by-side`, `tiles`, `statement` | layouts inside a slide; `tiles` staggers itself, and `side-by-side(equal: true)` makes its columns the same height |
 | `fit` | scales one block down to the room it has, for a wide table or a generated chart; no reveal may sit inside it |

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ written.
 | `anim`, `stagger`, `pause`, `alternatives` | reveal one thing, a series of things, everything after this point, one thing after another in the same place |
 | `morph`, `pin` | magic move across slides; `pin` names a glyph so the pairing follows the name rather than the shape |
 | `card`, `callout`, `side-by-side`, `tiles`, `statement` | layouts inside a slide; `tiles` staggers itself, and `side-by-side(equal: true)` makes its columns the same height |
+| `fit` | scales one block down to the room it has, for a wide table or a generated chart; no reveal may sit inside it |
 | `transition`, `speaker-note` | how this slide comes in, and what only you see |
 | `themes`, `theme` | the five built-in looks, and the builder behind them |
 | `video`, `embed`, `flipbook` | media, arbitrary web content in a sandboxed frame, and animation drawn frame by frame by Typst |

--- a/assets/typstage-0.1.0.js
+++ b/assets/typstage-0.1.0.js
@@ -11,6 +11,22 @@
   var SPRECHERBOX = document.getElementById("ts-speaker");
   var INK = document.getElementById("ts-ink");
 
+  // ── Links that point outside ──────────────────────────────────────────────
+  //
+  // A link on a slide leads away from the deck. Opening it in the same tab
+  // would take the talk with it, and there is no way back that a speaker wants
+  // to look for in front of a room.
+  //
+  // The anchors come out of `html.frame` and sit inside the SVG, where they
+  // carry `href` as well as `xlink:href`. Both are read, because which of the
+  // two Typst writes is not ours to decide.
+  document.querySelectorAll("a").forEach(function (a) {
+    var href = a.getAttribute("href") || a.getAttribute("xlink:href") || "";
+    if (!/^https?:/i.test(href)) return;
+    a.setAttribute("target", "_blank");
+    a.setAttribute("rel", "noopener");
+  });
+
   // ── The role, once and for good ───────────────────────────────────────────
   //
   // The same file carries two views: the talk and, with `#speaker` in the
@@ -274,12 +290,12 @@
             // the inner viewport keeps its size and no `resize` fires in
             // there. The message says "your box is new", and what to do about
             // it is the embedded document's business, not ours.
-            // Beide Maße, denn sie sagen Verschiedenes: `w` und `h` sind
-            // der Kasten in Punkten der Folie und damit in jedem Fenster
-            // dieselbe Zahl, `px` ist derselbe Kasten in Bildschirmpunkten
-            // und in jedem Fenster eine andere. Wer scharf zeichnen will,
-            // braucht die zweite; wer in allen Fenstern dasselbe zeigen
-            // will, die erste.
+            // Both measurements, because they say different things. `w` and
+            // `h` are the box in points of the slide and therefore the same
+            // number in every window; `px` is the same box in screen points
+            // and a different number in every window. Whoever wants to draw
+            // sharply needs the second, whoever wants every window to show
+            // the same thing needs the first.
             try {
               frame.contentWindow.postMessage({ typstage: 1, mass: 1,
                 w: w, h: h, px: skala }, "*");
@@ -542,14 +558,14 @@
     el.querySelectorAll("path").forEach(function (n) {
       var sw = strichBreite(n);
       if (sw <= 0) return;              // glyph outline, not a drawn stroke
-      // Gemessen wie bei den Glyphen und nicht mit `getBoundingClientRect`.
-      // Firefox rechnet dort den Strich mit, und zwar großzügiger als um seine
-      // halbe Breite: an derselben Bruchlinie meldet es 18,9 mal 5,2, wo die
-      // Geometrie 13,7 mal 0 ist und Chrome auch 13,7 mal 0 meldet. Weil hier
-      // gleich darauf noch einmal um die halbe Strichbreite verbreitert wird,
-      // geriet der Geist doppelt so hoch, und `preserveAspectRatio="none"` zog
-      // die Linie darauf. Gemeldet aus dem Forum als Bruchstriche, die während
-      // des Fluges kurz dick werden, in Chrome aber nicht.
+      // Measured the way the glyphs are, not with `getBoundingClientRect`.
+      // Firefox counts the stroke into that box, and more generously than by
+      // half its width: on the same fraction bar it reports 18.9 by 5.2 where
+      // the geometry is 13.7 by 0, and Chrome reports 13.7 by 0 as well.
+      // Because half a stroke width is added on each side right afterwards,
+      // the ghost came out twice as tall, and `preserveAspectRatio="none"`
+      // stretched the line onto it. Reported from the forum as fraction bars
+      // that briefly thicken during a flight, though not in Chrome.
       var r = glyphKasten(n);
       if (!r || (r.width <= 0 && r.height <= 0)) return;
       // Widen on screen too by half the stroke width, otherwise the ghost
@@ -2656,6 +2672,9 @@
     if (ROLLE === "speaker") return;
     if (OVERVIEW.dataset.on) return;
     if (e.target.closest && e.target.closest(".ts-embed")) return;
+    // A click on a link follows the link. Paging as well would leave the
+    // talk on a different slide than the one the speaker pointed at.
+    if (e.target.closest && e.target.closest("a")) return;
     goto(current + (e.clientX < innerWidth * 0.25 ? -1 : 1));
   });
   // ── Swiping ───────────────────────────────────────────────────────────────

--- a/assets/typstage-0.1.0.js
+++ b/assets/typstage-0.1.0.js
@@ -127,6 +127,22 @@
     return false;
   }
 
+  // The last step a selector still covers, or Infinity if it runs to the end
+  // of the slide. Only a selector with a last step has an "after" for an
+  // element to rest in.
+  function endeBei(at) {
+    var parts = String(at || "1-").split(","), e = 0;
+    for (var i = 0; i < parts.length; i++) {
+      var t = parts[i].trim();
+      if (!t) continue;
+      var k = t.indexOf("-");
+      if (k < 0) { e = Math.max(e, +t); continue; }
+      if (t.slice(k + 1) === "") return Infinity;
+      e = Math.max(e, +t.slice(k + 1));
+    }
+    return e;
+  }
+
   // ── Geometry ──────────────────────────────────────────────────────────────
   // Marks live in the background SVG. getCTM() maps them into viewBox
   // coordinates; the result is stored as ratios so any window size fits.
@@ -350,13 +366,76 @@
     a.onfinish = function () { el.style.opacity = "1"; a.cancel(); };
   }
 
-  function fadeOut(el, name, dur) {
+  // How far down a dimmed element goes. Not a taste, a measurement. Dimming
+  // composites the ink towards the ground, so the ground decides what it
+  // costs, and the value is the smallest hundredth at which body text still
+  // meets the 4.5 to 1 the package's contrast contract asks of it, on
+  // all five bundled palettes, upright and inverted, on the paper and on a
+  // card surface. The tightest of the twenty is `parchment` on its own paper:
+  // 4.57 at 0.65 and 4.44 at 0.64. The most forgiving is `mono` inverted at
+  // 8.60, because opacity costs far less on a dark ground than on a light
+  // one. Between full and dimmed there remain 1.94 to 3.23 to 1, so the step
+  // is plainly visible everywhere. The arithmetic is `contrast()` in
+  // `src/palettes.typ`.
+  //
+  // It holds for text in the ink colour, which is what a point is set in.
+  // Dimming something already quiet, a `muted` footer or an accent-coloured
+  // word, drops under the contract; the manual says so.
+  var DIM = 0.65;
+
+  function fadeOut(el, name, dur, von) {
     clearAnims(el);
     if (name === "none") { el.style.opacity = "0"; return; }
     var f = EFFECT[name] || EFFECT["fade"];
-    var a = el.animate([f[1], f[0]],
+    var ab = f[1];
+    // Leaving out of the dimmed state starts where the element stands. Taken
+    // from the effect's full end value it would flash back to full strength
+    // for one frame before it goes.
+    if (von != null && von !== 1) {
+      ab = {};
+      for (var k in f[1]) ab[k] = f[1][k];
+      ab.opacity = von;
+    }
+    var a = el.animate([ab, f[0]],
       { duration: dur, easing: EASE, fill: "both" });
     a.onfinish = function () { el.style.opacity = "0"; try { a.cancel(); } catch (e) {} };
+  }
+
+  // Between two resting opacities, with no effect and no travel. Dimming is
+  // not an entrance and not a departure: the point does not move, it only
+  // steps back or comes forward again.
+  function fadeTo(el, von, bis, dur) {
+    clearAnims(el);
+    var a = el.animate([{ opacity: von }, { opacity: bis }],
+      { duration: dur, easing: EASE, fill: "both" });
+    a.onfinish = function () {
+      el.style.opacity = String(bis); try { a.cancel(); } catch (e) {}
+    };
+  }
+
+  // The three states a sprite rests in, on the element as well as in the
+  // markup: 0 not drawn, 1 drawn muted, 2 drawn. `data-on` keeps meaning
+  // "is on the slide", so whatever asks that question -- a morph looking for
+  // its source, the pointer looking for a frame -- finds a dimmed element
+  // too, because it is on the slide.
+  function ruhe(el, z) {
+    if (z === 0) {
+      delete el.dataset.on; delete el.dataset.dim; el.style.opacity = "0";
+    } else if (z === 1) {
+      el.dataset.on = "1"; el.dataset.dim = "1";
+      el.style.opacity = String(DIM);
+    } else {
+      el.dataset.on = "1"; delete el.dataset.dim; el.style.opacity = "1";
+    }
+  }
+
+  // Which of the three a sprite is in on a given step.
+  function zustand(el, schritt) {
+    if (activeAt(el.dataset.at, schritt)) return 2;
+    // The cheap question first. Almost every selector runs to the end of the
+    // slide, and then there is nothing to look up.
+    if (schritt > endeBei(el.dataset.at) && erbt(el, "after") === "dimmed") return 1;
+    return 0;
   }
 
   // ── Magic move ────────────────────────────────────────────────────────────
@@ -1608,14 +1687,25 @@
     m.innerHTML = f.querySelector(".ts-bg").innerHTML + (cp ? cp.innerHTML : "");
     var ov = f.querySelector(".ts-ov");
     if (ov) {
+      // Read off the originals, applied to the copies further down. A nested
+      // element inherits `data-after` from its host, and that lookup needs the
+      // slide around it, which the detached copy no longer has.
+      var stufen = [];
+      ov.querySelectorAll(".ts-el").forEach(function (el) {
+        stufen.push(zustand(el, schritt));
+      });
       var k = ov.cloneNode(true);
       // A cloned iframe would load the foreign document a second time, a
       // cloned video would play sound a second time. Neither belongs in a
       // still image.
       k.querySelectorAll("iframe,video,audio").forEach(function (x) { x.remove(); });
-      k.querySelectorAll(".ts-el").forEach(function (el) {
+      k.querySelectorAll(".ts-el").forEach(function (el, i) {
         el.removeAttribute("data-hold");
-        el.style.opacity = activeAt(el.dataset.at, schritt) ? "1" : "0";
+        // The preview answers "what stands there after the next keypress",
+        // so it has to show the muted state too: otherwise a point that only
+        // steps back would look to the speaker as if it had gone.
+        var z = stufen[i];
+        el.style.opacity = z === 2 ? "1" : (z === 1 ? String(DIM) : "0");
       });
       m.appendChild(k);
     }
@@ -2202,24 +2292,37 @@
     });
 
     SLIDES[dst.slide].querySelectorAll(".ts-el").forEach(function (el) {
-      var an = activeAt(el.dataset.at, dst.step);
       var d = +erbt(el, "duration") || CFG.duration;
       var delay = back ? 0 : (+erbt(el, "delay") || 0);
+      // Where the element stands now and where it belongs. `data-on` alone no
+      // longer answers the first question: drawn muted is a third state, and
+      // it has to be told apart from drawn, or paging back would find nothing
+      // to bring up again.
+      var war = el.dataset.on !== "1" ? 0 : (el.dataset.dim === "1" ? 1 : 2);
+      var wird = zustand(el, dst.step);
 
-      if (instant || changed) {
-        clearAnims(el);
-        if (an) { el.dataset.on = "1"; el.style.opacity = "1"; }
-        else { delete el.dataset.on; el.style.opacity = "0"; }
-        return;
-      }
+      // Entering a slide or jumping into it plays no effects, so the whole run
+      // is replayed as state. That is what puts a dimmed element back where it
+      // belongs after a reload, after paging in from the other side, and in
+      // the speaker view.
+      if (instant || changed) { clearAnims(el); ruhe(el, wird); return; }
+      if (wird === war) return;
+      ruhe(el, wird);
 
-      if (an && el.dataset.on !== "1") {
-        el.dataset.on = "1";
-        fadeIn(el, erbt(el, "enter") || "fade-up", d, delay);
-      } else if (!an && el.dataset.on === "1") {
-        delete el.dataset.on;
-        if (back) fadeOut(el, erbt(el, "enter") || "fade-up", d);
-        else fadeOut(el, erbt(el, "exit") || "fade", d * 0.75);
+      if (war === 0) {
+        // Straight to full is the entrance. Straight to muted only happens on
+        // a jump that skipped the whole range, and then the point has no
+        // arrival to play: it simply is there, quietly.
+        if (wird === 2) fadeIn(el, erbt(el, "enter") || "fade-up", d, delay);
+        else fadeTo(el, 0, DIM, d);
+      } else if (wird === 0) {
+        var von = war === 1 ? DIM : 1;
+        if (back) fadeOut(el, erbt(el, "enter") || "fade-up", d, von);
+        else fadeOut(el, erbt(el, "exit") || "fade", d * 0.75, von);
+      } else if (wird === 1) {
+        fadeTo(el, 1, DIM, d);
+      } else {
+        fadeTo(el, DIM, 1, d);
       }
     });
 

--- a/docs/content-en.typ
+++ b/docs/content-en.typ
@@ -1181,6 +1181,161 @@ A section slide has no subtitle in typstage, so the list names none.
 ]
 
 
+== `info()`: what the deck knows about itself
+
+Labels say how a shape the package builds looks. They do not say what stands
+in it. The slide number, the fraction, the chapter in the running header --
+those numbers were the package's own, and anyone who wanted a footer of their
+own had to count along. `info()` hands them out:
+
+#show-code[```typ
+#context {
+  let deck = info()
+  [#deck.section.title #h(1fr) #deck.slide.number / #deck.slide.total]
+}
+```]
+
+It is the same reading the built-in footer does. Every number the package
+prints on a slide -- the slide number, the fraction, the length of the progress
+bar, the running header -- comes out of this dictionary and out of no second
+count. A hand-built footer and the built-in one cannot print different numbers.
+
+What comes back:
+
+#table(
+  columns: (auto, 1fr),
+  stroke: 0.5pt + luma(180),
+  table.header([*Field*], [*What is in it*]),
+  [`title`, `subtitle`], [The deck's title and subtitle, as `presentation` or a
+    `title-slide` received them],
+  [`author`, `date`], [From the same place. `date` is whatever was passed, a
+    `datetime` or content],
+  [`slide.number`], [This slide. Counted the way the footer counts, so title
+    and section slides are not in it],
+  [`slide.total`], [How many slides are counted],
+  [`slide.numbered`], [Whether this slide is one of them. `false` on a title
+    and on a section slide],
+  [`step.number`], [The step the calling content itself stands on],
+  [`step.total`], [How many steps this slide has],
+  [`section.number`], [Which section is running, `0` before the first],
+  [`section.total`], [How many sections the deck has],
+  [`section.title`], [Its title, or `none` before the first],
+)
+
+One number stands deliberately apart: the speaker view and the overview count
+*every* slide, title and section slides included, while `info().slide.total`
+counts the way the footer counts and leaves them out. On a sample with one
+title slide, two section slides and three ordinary ones, that is 6 against 3.
+
+=== Two counts, not one
+
+A deck that counts pages would get by with one number. This one counts slides
+*and* steps, and the two are different things: a slide is one picture, a step
+is one press of the arrow key. So they stand apart, and they are called what
+they are called throughout this manual.
+
+`step.number` is the step the calling content itself stands on: `1` in the body
+of a slide, and inside an `anim`, a `stagger` or an `alternatives` the step of
+that reveal -- and where a reveal covers several steps, the first of them. That is the difference that matters -- a display naming the
+current step has to sit inside the reveals, because the browser typesets
+nothing anew:
+
+#show-code[```typ
+#let where = context {
+  let d = info()
+  [Step #d.step.number of #d.step.total]
+}
+
+== Four versions
+#alternatives(where, where, where, where)
+```]
+
+Paging through, that prints "Step 1 of 4" up to "Step 4 of 4" -- measured on a
+sample with nine steps, at every one of them.
+
+On paper there is no current step: the page shows the slide in its final state,
+everything at once. There `step.number` equals `step.total`.
+
+#info[
+  `step.total` counts what the runtime in the browser counts. Cross-checked on
+  a deck holding one of every building block that consumes a step -- `pause`,
+  `stagger`, `anim` with and without a number, `alternatives`, `tiles`,
+  `morph`, `video`, `flipbook`: on all nine slides with a body `info()` names
+  the same number the runtime in the browser counts, and the PDF names it too.
+]
+
+=== Where a hand-built footer goes
+
+typstage draws no footer on a title or a section slide. Anyone building their
+own faces the question of what belongs in the counter slot there -- and the
+answer is nothing. `slide.numbered` says when that is the case:
+
+#show-code[```typ
+#let footline = context {
+  let d = info()
+  let number = if d.slide.numbered [#d.slide.number / #d.slide.total] else []
+  place(bottom + right, text(size: 12pt, fill: muted, number))
+}
+```]
+
+On an ordinary slide it goes into the body, that is, into the slide itself:
+
+#show-code[```typ
+== A slide
+#footline
+The text of the slide.
+```]
+
+On the title and the section slides it has to go into the theme: those two
+pictures are functions, and a function wrapped around another adds to it rather
+than replacing it.
+
+#show-code[```typ
+#let base = themes.default
+#let with-foot(f) = (t, s, geo) => { f(t, s, geo); footline }
+
+#show: presentation.with(
+  theme: base + (title-slide: with-foot(base.title-slide),
+                 section: with-foot(base.section)),
+)
+```]
+
+#warning[
+  *Not through `style:`.* The hook looks like the convenient shortcut:
+  `style: it => { footline; it }` would put the footer on every slide without
+  writing it out once per slide. But it is also the template each moving
+  element is typeset with a second time -- and whatever *draws* in there is
+  drawn again inside every sprite.
+
+  Measured on a deck with three reveals per slide: in the browser the footer
+  stood on the slide four times instead of once, and inside a flip book of six
+  frames another six times. Counted in the body, same deck, same sprites: once.
+  On paper it does not show, there are no sprites there.
+
+  `style:` is for typography -- typeface, size, colour, leading -- and for that
+  it is exactly right: background and sprite need the same.
+]
+
+#info[
+  A footer placed in the body sits at the bottom of the *body*, not at the
+  bottom of the slide; the theme's `foot-gap` lies in between. A `dy:` on the
+  `place` moves it where it belongs.
+]
+
+#warning[
+  `info()` reads the state of the slide being typeset and therefore needs a
+  `context` around it. *Before* the presentation there is nothing to read;
+  there it stops with a message rather than handing out zeros.
+
+  *After* it, no: whoever passes the slides as arguments and writes an `info()`
+  below the call still gets the last slide's numbers. Clearing the deck's own
+  record at the end would close that, but measured it costs layout headroom: a
+  slide with one reveal beside a `tiles` went from no warning to three
+  "did not converge" ones. A corner nobody stands in is not worth that, and in
+  the show-rule notation nothing comes after the deck anyway.
+]
+
+
 = Handing it on
 
 The aim of this chapter: getting the talk to where it will be given.

--- a/docs/content-en.typ
+++ b/docs/content-en.typ
@@ -850,6 +850,193 @@ whole pictures rather than variations on one another.
   checks them and says which values it accepts.
 ]
 
+== Colour, separately: palettes
+
+A theme says how a slide is *built*; a *palette* says what colour it is. The
+two vary separately, which is why they are separate arguments: the classroom
+design is still the classroom design in a darkened room. A palette overwrites
+*partially*, only the entries written down:
+
+#show-code[```typ
+#show: presentation.with(theme: themes.lesson, palette: (accent: blue))
+#show: presentation.with(theme: themes.lesson, palette: palettes.dark)
+```]
+
+A palette carries eight entries, and they are exactly a theme's colour
+entries: `paper` the ground of the slide, `ink` the body text, `strong` the
+carrying dark colour, `accent` the signal colour, `muted` the secondary
+matter, `surface` the ground of a card, `border` its edge, and `inverted`,
+whether light text stands on a dark ground. An entry that does not exist is
+refused: `palette: (acent: blue)` stops with a message rather than quietly
+doing nothing.
+
+Five ship with the package, and each composes with each of the five themes:
+
+#table(
+  columns: (auto, 1fr),
+  stroke: 0.5pt + luma(180),
+  table.header([*Palette*], [*Where it comes from*]),
+  [`palettes.light`], [Exactly the colours of `themes.default`, so this one
+    changes nothing about the default.],
+  [`palettes.mono`], [The greys of `themes.plain`, two of them moved so it
+    passes the contract below.],
+  [`palettes.textbook`], [The textbook colours measured for `themes.lesson`,
+    one grey moved.],
+  [`palettes.parchment`], [The laid paper of `themes.editorial`, two tones
+    moved.],
+  [`palettes.dark`], [The dark ground of `themes.night`, with a deeper
+    accent.],
+)
+
+Which is the whole reason no further theme is needed for the dark room:
+*darkness is a palette rather than a design.* `themes.lesson` under
+`palettes.dark` is still the lesson design, only dark.
+
+`themes.night` stays a theme all the same, and the reason is measured. Its
+cyan `#5ec8f2` carries the title on night's own ground at 9.77 to 1, and on
+the ground an inverted slide lays behind it at 1.59. A colour that holds on
+both would have to sit between roughly 0.13 and 0.23 relative luminance; the
+cyan sits at 0.52. So `palettes.dark` takes a deeper blue that holds on both,
+and `themes.night` keeps the cyan it was designed around.
+
+#warning[
+  Two colours of a theme are not palette entries: `title-fill` and
+  `rule-fill`. Whether they follow is up to the theme. All five bundled ones
+  let them follow -- either as a function of the palette,
+  `title-fill: p => p.strong`, or as `none`, which means the accent and
+  follows with it. Both changed type for that: reading `themes.X.title-fill`
+  used to give a colour and now gives a function, and `rule-fill` gives `none`
+  where it gave the accent. Writing them, `themes.X + (title-fill: red)`, is
+  unchanged. A theme of your own that names a fixed colour there keeps it
+  under every palette. That is deliberate: a colour someone named out loud is
+  not swapped behind their back.
+]
+
+And `themes.night` stays a theme all the same. Its cyan `#5ec8f2` measures
+9.77 to 1 on the dark ground, which is why it glows there, but only 1.59 to 1
+on its own text colour, and that is exactly what an inverted slide puts behind
+it. `palettes.dark` therefore takes a deeper tone. The theme keeps its own; it
+is a design decision, and a measured one rather than an oversight.
+
+== Inverting one slide
+
+For the slide that carries a single number there is `invert`. The ground
+becomes the palette's text colour and the text becomes its ground; `muted`,
+`border` and `surface` are mixed from those two, and `strong` and `accent`
+carry over unchanged. The chrome follows: running head, footer, slide number
+and progress bar are set in the same colours as the slide beneath them, and so
+are `card` and `callout`.
+
+In the heading notation it is a marker in the slide body, like `#pause`:
+
+#show-code[```typ
+== Reached by 2026
+#invert
+#statement[74 %]
+```]
+
+In the argument notation it is an argument of `slide`:
+
+#show-code[```typ
+#slide([Reached by 2026], invert: true)[#statement[74 %]]
+```]
+
+#warning[
+  Only a regular slide inverts. A title slide and a section slide are whole
+  pictures the theme draws itself, and three of the five bundled themes build
+  them from colours an inversion does not reach; neither takes the argument.
+
+  The `#invert` marker is found wherever the body can be walked: at the top
+  level, inside a `block` or an `align`, in a table cell, in a grid, however
+  deeply nested, in the slide's own heading, and behind `#set` and `#show`
+  rules. It is *not* found where the content is handed to a closure the walk
+  cannot enter -- inside `context`, `fit`, `anim`, `card` or `alternatives` --
+  and there the slide is simply left as it is, without a word. Measured, those
+  five are the whole of it. Where you need one of them, write the slide as
+  `slide(invert: true)`, which never depends on the walk.
+]
+
+== The contrast contract
+
+The bundled palettes are measured before they ship. The arithmetic is real
+WCAG 2 contrast: each channel linearised, from those the relative luminance
+$0.2126 R + 0.7152 G + 0.0722 B$, and from two luminances the ratio
+$(L_"light" + 0.05) \/ (L_"dark" + 0.05)$. Six pairs are checked:
+
+#table(
+  columns: (auto, auto, 1fr),
+  stroke: 0.5pt + luma(180),
+  table.header([*Pair*], [*At least*], [*What for*]),
+  [`ink` on `paper`], [4.5], [body text on the slide],
+  [`ink` on `surface`], [4.5], [body text in a card],
+  [`muted` on `paper`], [4.5], [footer, subtitle, running head],
+  [`accent` on `paper`], [3.0], [rules, progress bar, marker],
+  [`accent` on `ink`], [3.0], [the same on an inverted slide],
+  [`border` on `paper`], [1.2], [hairlines],
+)
+
+Every one of the five palettes is checked, and its inverted form with it, by an
+assertion in `src/palettes.typ` that runs when the package is loaded. A colour
+moved there that breaks the contract stops the build and names the number it
+missed.
+
+#warning[
+  *The contract holds only the bundled palettes.* A palette of your own faces
+  no such gate: it is neither warned about nor recoloured. `palette-report(…)`
+  hands back the same measurement as a list for anyone who wants to see it:
+
+  #show-code[```typ
+  #for f in palette-report((paper: white, ink: black, surface: white,
+                            muted: luma(55%), accent: blue, border: luma(86%))) [
+    #f.pair: #calc.round(f.ratio, digits: 2) (wants #f.min) #f.ok \
+  ]
+  ```]
+
+  `contrast(a, b)` is the arithmetic itself and takes any two colours.
+]
+
+*And the five themes do not all pass it.* The contract was run over them before
+the palettes existed, and the result stands here rather than being quietly
+coloured away:
+
+#table(
+  columns: (auto, 1fr),
+  stroke: 0.5pt + luma(180),
+  table.header([*Theme*], [*What falls short*]),
+  [`themes.default`], [nothing, all six pairs hold],
+  [`themes.lesson`], [`muted` on `paper` measures 4.25 against 4.5],
+  [`themes.night`], [`accent` on `ink` measures 1.59 against 3.0],
+  [`themes.plain`], [`muted` on `paper` measures 3.35 against 4.5;
+    `accent` on `ink` measures 1.27 against 3.0],
+  [`themes.editorial`], [`muted` on `paper` measures 3.51 against 4.5;
+    `accent` on `paper` measures 2.84 against 3.0],
+)
+
+None of those colours was changed. They sit in designs that were measured in
+their own right, those of `themes.lesson` off a sample page of a German maths
+textbook, and moving them would have changed every deck already written. What
+`muted` carries is the secondary matter: slide number, subtitle, running head.
+Anyone who wants the numbers met lays the matching palette over the theme:
+
+#show-code[```typ
+#show: presentation.with(theme: themes.editorial, palette: palettes.parchment)
+```]
+
+#warning[
+  *The text colour is never inferred from the fill.* A muted sage such as
+  `#aebdb3` reads as "light" to a luminance rule, yet white on it measures
+  1.96 to 1, far under the 4.5 that body text wants. That is why the package
+  measures with `contrast` and recolours nothing on its own.
+
+  The one exception lives in the theme rather than in the palette, and it is a
+  measurement too. Where a theme sets `strong` as *text*, the heading in
+  `themes.lesson`, the section title in `themes.plain`, it picks between
+  `strong` and `ink` by measured contrast against the ground, because one
+  colour cannot be a dark band and text on a dark ground at the same time.
+  Where the colour named first suffices, and it does for all five themes in
+  their own colours, that is the one that stays.
+]
+
 == The canvas
 
 `width`, `height` and `margin` on `presentation` set the canvas. The default is
@@ -1697,6 +1884,13 @@ then media and the bridge, and last the measurements and colours.
 // section pictures are building blocks of those and do not stand alone.
 #show-module(read("../src/themes.typ"), name: "typstage",
              only: ("theme", "themes"))
+
+== Palettes
+
+// Only what `lib.typ` hands out. `kanal`, `leuchtdichte`, `lesbar` and the
+// check itself are internals.
+#show-module(read("../src/palettes.typ"), name: "typstage",
+             only: ("palettes", "contrast", "palette-report"))
 
 == Media and embeds
 

--- a/docs/content-en.typ
+++ b/docs/content-en.typ
@@ -990,6 +990,100 @@ view nor the handout. `speaker-note` refuses that with a message.
 The arithmetic is taken from mosaic, which took it from Touying 0.7.4; Touying
 credits the work on it to Andreas Kröpelin (Polylux PR #91) and to ntjess.
 
+=== overflow: the checking pass before the talk
+
+`fit` answers the one block whose size you already suspect. `overflow` answers
+the question you cannot ask slide by slide: does anything in this deck run over
+the room it has? It measures every slide body against the room the theme gives
+it and names the ones that do not fit.
+
+#show-code(```typ
+#show: presentation.with(overflow: "error")
+```)
+
+It is off by default and meant to be switched on for a run, not left on while
+writing.
+
+A deck needs this more than a document does. A page one leafs through shows an
+overrun: the line simply stands past the margin and the eye catches it. A
+typstage slide goes into an SVG frame of fixed size and is scaled in the
+browser, so what sticks out is cut away or drawn beside the slide -- and a talk
+one clicks through shows that at the projector.
+
+/ `"none"`: nothing is measured. The default.
+/ `"error"`: the whole deck is built, and it then stops with *every* place at
+  once rather than with the first. One run, the whole list.
+/ `"record"`: it carries on and files a queryable record per finding instead,
+  for a tool or a build script. Typst gives a package no warning channel, so
+  `"record"` prints nothing by itself.
+
+The message names the slide, the step and the amount (shortened here, the
+prose around the list is left out):
+
+#show-code(```
+error: assertion failed: typstage: 2 slides run over the room the body has. …
+  slide 2, from step 1 at the earliest: 311.14pt too tall, 675.76pt of content in 364.61pt of room
+  slide 3, from step 2 at the earliest: 296.49pt too tall, 661.1pt of content in 364.61pt of room
+Shorten the slide, split it, or put the block that does not fit into fit(). …
+```)
+
+*Why the step says "at the earliest".* A slide is exactly as tall on step one
+as on step five: every tracked element holds its full room with `hide()` from
+the start, so whether the body fits is a question about the slide, not about
+the step. What changes with the step is only what is *drawn*. An `anim` hanging
+over the bottom edge is invisible until its step, and only then is there
+something to see.
+
+The step is worked out from the reveals: everything that only arrives after
+step k is invisible there, and if the overrun is larger than all of it put
+together, something is hanging over the edge on step k already. That is a lower
+bound and not an exact answer, because the sum counts the reveals and nothing
+else -- the gaps between them, block spacing, a `v()`, count in the body's
+height and in no reveal. Measured: a 350pt box, a `v(100pt)` and an
+`anim(at: 4)` below it are reported from step 1, while the overrun only reaches
+the screen on step 4. Where the thing that overruns is itself a reveal and
+nothing empty stands above it, the step is exact: `anim(at: 3)` is reported
+from step 3. *The slide is named correctly either way*, and that is the part to
+act on. On paper no step is named at all, because every step stands on the page
+at once; in the records that shows as `step: 0`.
+
+The records are read with `typst eval`, and for that the deck has to be on
+`overflow: "record"` -- on `"error"` this command stops with the error instead:
+
+#show-code(```sh
+typst eval --target html --features html --in deck.typ \
+  'query(<typstage-overflow>).map(e => e.value)'
+```)
+
+which gives one entry per finding:
+
+#show-code(```json
+[{"slide":2,"step":1,"height":675.76,"room":364.61,"over":311.14},
+ {"slide":3,"step":2,"height":661.1,"room":364.61,"over":296.49}]
+```)
+
+#info[
+  *What the check does not see.* Only the height is measured. `measure` caps
+  the width it reports at the width it is given, so a body that is too wide
+  cannot be told from one that fills its column; `fit` is the answer to that
+  case, and the two belong together -- the check finds the slide, `fit` fixes
+  the block.
+
+  Four things are missed rather than reported. A `height: 100%` inside the body
+  measures 0 and a `1fr` collapses. Anything drawing outside its own layout box
+  -- `scale`, `move`, `place` with an offset -- is invisible to a measurement
+  altogether. And title and section slides are never measured: the theme draws
+  them with `place` and they have no body block to overrun.
+
+  One thing is reported where nothing shows: trailing spacing, a `v()` at the
+  end of a body, takes room in the measurement and draws nothing.
+]
+
+Measured over the six example decks: in HTML the pass costs noticeably more
+time, between 1.2 and 1.5 times depending on the deck and on how the process
+start is accounted for; on paper it costs a little, a few milliseconds per
+deck. Run over all six decks it reports nothing -- none of them overruns.
+
 == Labels: reaching every shape the package builds
 
 Every shape typstage draws on a slide itself -- the ground, the header band,

--- a/docs/content-en.typ
+++ b/docs/content-en.typ
@@ -800,6 +800,12 @@ argument `note` on `slide`:
 The note appears in the speaker view, on `s` in the bar, and on the handout. It
 produces nothing in the deck PDF.
 
+A note has to carry text. The speaker view transports it as a string and the
+handout prints it where there is text, so a note built purely out of layout --
+a `fit`, a bare `rect`, an image -- would arrive nowhere. That is refused with
+a message rather than dropped in silence. What is meant to be *seen* belongs on
+the slide.
+
 = Making it your own
 
 The aim of this chapter: a deck that looks like yours and not like the package.
@@ -884,6 +890,105 @@ draws scales along.
   hand-counted `at:` on each.
 / `statement`: One large sentence, centred, for the slide that carries a single
   claim.
+/ `fit`: Scales one block down to the room it has, for content whose size the
+  deck does not set itself.
+
+=== fit: working content into the room it has
+
+For the one piece whose size is not written in the deck: the wide table out of
+the analysis, the generated chart, the list that came from a data file. With
+nothing in between, such a block runs over the edge of the slide. In the PDF it
+is still to be seen standing there; in the browser the slide sits in a frame of
+fixed size and whatever reaches past it is cut away.
+
+#show-code(```typ
+== Regression results
+#fit(wrap: false, my-table)
+```)
+
+`wrap: false` because the block is a table. Everything that lays itself out in
+columns wants to be measured as it stands; the reason follows two paragraphs
+down, and it is the one setting worth knowing before the first use.
+
+`fit` measures the block against the place it stands in and scales it
+geometrically, so the proportions are kept and no factor is given by hand.
+Measured on a table of 9 columns and 22 data rows: the body of a slide in the
+`plain` theme is 777.89 pt wide and 364.61 pt tall, the table measures
+572.09 pt #sym.times 571.60 pt and is therefore 207 pt too tall. `fit` works
+out 63.8 % and sets it 364.6 pt tall. The same in the HTML and in the PDF,
+because the arithmetic happens at compile time.
+
+*Width first, then smaller.* The block is offered the full width before it is
+measured. A paragraph or a list then wraps into the space instead of shrinking,
+and only what is still too tall afterwards is scaled. Measured on `lorem(60)`:
+set free, the paragraph is a single line of 3490 pt; offered the width of the
+body it becomes 777.89 pt #sym.times 111.06 pt and so already fits. The factor
+comes to 100 %, `fit` leaves the block alone, and the slide with the fit and
+the slide without it are pixel for pixel the same across the paragraph.
+Without the offer of the width, the same paragraph would come to 22.3 % and
+stand as a thread across the slide.
+
+A table, a chart or a drawing rearranges itself instead when it is offered a
+narrower width, and that changes the picture rather than its size.
+`wrap: false` measures such a block exactly as it stands:
+
+#show-code(```typ
+#fit(wrap: false, my-table)
+```)
+
+Measured on a table of 24 columns that is 1316 pt wide when set free: with the
+default `wrap: true`, Typst squeezes the columns into the 777.89 pt of the
+body, the digits overlap, and the factor comes out at 100 %, so nothing is
+scaled. With `wrap: false`, `fit` works out 59.1 % and the columns keep their
+proportions.
+
+*It only shrinks.* `grow: true` also blows up what is smaller than its place,
+for the one large number meant to fill the slide. `shrink: false` takes the
+shrinking away and leaves only the growing.
+
+#show-code(```typ
+#fit(grow: true)[42%]
+```)
+
+`width` and `height` take `auto`, a length or a ratio. On `height: auto` the
+block takes what is left over below the rest of the slide's content, so a fit
+under two bullet points reckons with the bullet points. That has a flip side
+wherever something encloses the fit: inside a `card` the box becomes
+slide-tall, is cut off at the bottom, and whatever follows the card falls off
+the slide -- measured in both outputs. The `1fr` is doing that, not the
+scaling: a `card` around a bare `block(height: 1fr)` behaves the same. Give
+`height:` explicitly inside a card, and the fit reckons with that instead.
+
+#warning[
+  *No reveal inside a `fit`.* Two things do not survive being measured. A
+  `pause` is found by walking the slide body, and a fitted block is a closure
+  that walk cannot enter: measured on a slide carrying two pauses, the step
+  count fell from three to one, and nothing said so. And a measured block has
+  no height to reckon against -- the width is the one a wrapping fit hands in,
+  but the height comes back unbounded, and that is the axis on which a tracked
+  element resolves its size and reserves the room for its marker. Measured: an
+  `anim` inside a fit was not scaled at all and ran off the bottom of the
+  slide.
+
+  `fit` therefore stops with a message that names the thing, for `pause`,
+  `anim`, `stagger`, `alternatives`, `morph`, `tiles`, `video`, `embed` and
+  `flipbook` -- in both outputs, and also when the fit sits inside another fit.
+  The way round it is to put the fit *inside* the reveal rather than around it:
+
+  ```typ
+  #anim(fit(wrap: false, my-table))   // yes
+  #fit(anim(my-table))                // no
+  ```
+]
+
+`speaker-note` and `bridge-job` are allowed inside a fit. They settle no
+geometry, and a `measure` commits no state, so both were measured to arrive
+exactly once. The other direction is the one that does not work: a note made
+only of a `fit` carries no text and therefore reaches neither the presenter
+view nor the handout. `speaker-note` refuses that with a message.
+
+The arithmetic is taken from mosaic, which took it from Touying 0.7.4; Touying
+credits the work on it to Andreas Kröpelin (Polylux PR #91) and to ntjess.
 
 == Labels: reaching every shape the package builds
 

--- a/docs/content-en.typ
+++ b/docs/content-en.typ
@@ -74,6 +74,22 @@ This manual is ordered by intent rather than by function:
   The typeset examples in this manual are paper and therefore show the final
   state, everything at once. What happens one after another in the browser is
   said in the text beside them or as a comment in the source.
+
+  Every `typ` listing here is compiled against the real package before the site
+  is built, by `python3 .github/scripts/pruefe-beispiele.py`, so that no example
+  survives a rename in the package that makes it invalid. What the run does
+  *not* do belongs in the same breath: most listings are fragments rather than
+  whole files, so it wraps each one in a slide and checks that it compiles
+  there, not that the slide then looks right. Lines that deliberately raise an
+  error are marked as such and have to keep failing, and they name what they
+  have to fail at -- a line that breaks for some other reason is a failed
+  check, not a passed one. A line that does compile but does not do what was
+  wanted ("has no effect", "too late") it cannot tell from a correct one. It
+  compiles for the browser, not for paper, and it never looks at the prose
+  beside a listing -- which is where a stale number likes to sit. Listings in
+  other languages are left alone and counted, so nobody loses one by writing
+  the wrong fence. And an example whose companion package is missing is
+  skipped, and the run says which.
 ]
 
 = Your first presentation
@@ -86,30 +102,11 @@ without detours.
 No more than this is needed. An import, a show rule, and headings. The
 following file is complete and can be typed out:
 
-#show-code[```typ
-#import "@schule/typstage:0.1.0": *
-
-#show: presentation.with(
-  title: [The Pythagorean Theorem],
-  subtitle: [A derivation in four steps],
-  author: [Mathematics · Year 9],
-  date: datetime.today(),
-  transition: "slide",
-)
-
-= What this is about
-
-== The claim
-
-#speaker-note[Show the dissection first, then the formula, not the other way round.]
-
-In a right-angled triangle the two shorter sides together carry as much area
-as the longest one.
-
-#pause
-
-And that is the formula: $a^2 + b^2 = c^2$
-```]
+// Read from the file rather than copied out: "complete and can be typed out"
+// is a promise, and it only holds if these are the very bytes that
+// `.github/scripts/pruefe-beispiele.py` compiles.
+#show-code(raw(read("../examples/handbuch/first-deck.typ").trim(),
+               block: true, lang: "typ"))
 
 A first-level heading is a section slide, a second-level heading is a slide,
 and the text below it is its body. That is the whole structure.
@@ -318,6 +315,7 @@ drawn muted, legible but no longer the thing being talked about.
 
 #show-code[```typ
 #anim(at: "2-3", after: "dimmed")[A passing remark.]
+#anim(at: 4)[And on with the talk.]
 ```]
 
 Nothing moves and nothing is recoloured: the element settles to 65 percent
@@ -328,6 +326,11 @@ opacity and comes back up when you page back. `after` has exactly two values,
 slide, and what never leaves has no after; the package says so as an error
 rather than quietly doing nothing. `at: "3"` is that one step, `at: "2-3"` a
 range.
+
+The slide also needs a step after the range, which is what the second line
+above is for. If the range ends with the slide there is no step left on which
+the element could be seen muted; it would behave exactly like the default, and
+nothing would say so. That, too, is an error at compile time.
 
 *On paper `after` does nothing.* A page shows every step at once, and a point
 that is only quiet because the talk has moved past it has no past on a handout.
@@ -469,7 +472,7 @@ A frame with a `bridge:` has a name, and `bridge-job` sends it a dictionary
 when a step arrives:
 
 #show-code[```typ
-#embed(html: lamp, bridge: "lamp", width: 100%, height: 190pt)
+#embed(html: "…", bridge: "lamp", width: 100%, height: 190pt)
 
 #bridge-job("lamp", (color: "#16a34a"), at: 2)
 #bridge-job("lamp", (color: "#eb5e28"), at: 3)
@@ -497,6 +500,7 @@ applets.
 
 == Video
 
+// check: folie dateien=still.png
 #show-code[```typ
 #video("clip.mp4", width: 100%, height: 260pt, poster: image("still.png"))
 ```]
@@ -516,22 +520,27 @@ before it runs and what the PDF shows in its place.
 `flipbook` lets Typst render the motion itself, frame by frame:
 
 #show-code[```typ
-#flipbook(t => cetz.canvas({ … }), frames: 30, fps: 30,
-          width: 220pt, height: 160pt)
+#flipbook(
+  t => box(width: 100%, height: 100%,
+    place(left + horizon, dx: t * 88%, circle(radius: 9pt, fill: accent))),
+  frames: 24, fps: 20, width: 100%, height: 46pt,
+)
 ```]
 
-The function receives `t` running from 0 to 1 and is called once per frame.
-Every frame sits in the file as SVG and stays sharp at any size. That makes it
-the tool for motion that Typst can draw and CSS cannot: a curve being traced, a
-mechanism turning, a diagram assembling itself.
+The function receives `t` running from 0 to 1 and is called once per frame, and
+it may draw with anything Typst has, CeTZ and Fletcher included. Every frame
+sits in the file as SVG and stays sharp at any size. That makes it the tool for
+motion that Typst can draw and CSS cannot: a curve being traced, a mechanism
+turning, a diagram assembling itself.
 
 `loop`, `pingpong` and `still` decide how it plays and which frame stands on
 paper.
 
 #warning[
-  Thirty frames are thirty typeset drawings. That is the most expensive element
-  in this package, in compile time and in file size alike, and it is worth
-  reaching for only where the motion carries the argument.
+  Every frame is really typeset. Twenty-four frames are twenty-four layouts and
+  twenty-four SVG trees in the file. That is the most expensive element in this
+  package, in compile time and in file size alike, and it is worth reaching for
+  only where the motion carries the argument.
 ]
 
 = Developing a calculation
@@ -842,6 +851,7 @@ Since Typst 0.15 one compilation can write several files. That suits this
 package, because talk, deck and handout differ only in their target and in one
 argument. `bundle` writes all three at once:
 
+// check: dokument ziel=bundle
 #show-code[```typ
 #bundle(
   theme: themes.lesson,
@@ -1025,6 +1035,7 @@ In the heading notation it is a marker in the slide body, like `#pause`:
 
 In the argument notation it is an argument of `slide`:
 
+// check: argument
 #show-code[```typ
 #slide([Reached by 2026], invert: true)[#statement[74 %]]
 ```]
@@ -1176,6 +1187,7 @@ nothing in between, such a block runs over the edge of the slide. In the PDF it
 is still to be seen standing there; in the browser the slide sits in a frame of
 fixed size and whatever reaches past it is cut away.
 
+// check: folgen pre=tabelle
 #show-code(```typ
 == Regression results
 #fit(wrap: false, my-table)
@@ -1207,6 +1219,7 @@ A table, a chart or a drawing rearranges itself instead when it is offered a
 narrower width, and that changes the picture rather than its size.
 `wrap: false` measures such a block exactly as it stands:
 
+// check: folie pre=tabelle
 #show-code(```typ
 #fit(wrap: false, my-table)
 ```)
@@ -1250,6 +1263,7 @@ scaling: a `card` around a bare `block(height: 1fr)` behaves the same. Give
   `flipbook` -- in both outputs, and also when the fit sits inside another fit.
   The way round it is to put the fit *inside* the reveal rather than around it:
 
+  // check: folie pre=tabelle fehlt=2 weil=cannot_stand_inside_fit
   ```typ
   #anim(fit(wrap: false, my-table))   // yes
   #fit(anim(my-table))                // no
@@ -1754,6 +1768,7 @@ answer is nothing. `slide.numbered` says when that is the case:
 
 On an ordinary slide it goes into the body, that is, into the slide itself:
 
+// check: folgen davor
 #show-code[```typ
 == A slide
 #footline

--- a/docs/content-en.typ
+++ b/docs/content-en.typ
@@ -866,6 +866,11 @@ draws scales along.
   document, so shared typography has to go here. A `#set text` after the show
   rule reaches the slides but not the flying pieces, and the difference only
   shows up mid-flight.
+
+  For the shapes typstage draws itself there is a second route: label rules
+  before `#show: presentation`. They reach more than `style` does, because
+  they also reach the header, the footer and the title slide. See /Labels:
+  reaching every shape the package builds/ below.
 ]
 
 == Building blocks for the body
@@ -879,6 +884,302 @@ draws scales along.
   hand-counted `at:` on each.
 / `statement`: One large sentence, centred, for the slide that carries a single
   claim.
+
+== Labels: reaching every shape the package builds
+
+Every shape typstage draws on a slide itself -- the ground, the header band,
+the slide title, the footer, the progress indicator, the card, the callout,
+the statement, the title and section slides, the box that stands in for a
+video -- carries a fixed Typst label. That makes it addressable from outside:
+an ordinary `show` rule is enough, no theme key, no fork.
+
+#show-code[```typ
+#import "@schule/typstage:0.1.0": *
+
+#show label("ts-slide-header-band"): set rect(fill: rgb("#4c1d95"))
+#show label("ts-slide-title"): set text(fill: rgb("#fde047"), style: "italic")
+#show label("ts-card"): set block(fill: rgb("#eef2ff"))
+#show label("ts-statement"): set text(fill: rgb("#be123c"), weight: "bold")
+
+#show: presentation.with(theme: themes.default)
+```]
+
+Two kinds of rule cover all of it, split by what they touch: the *surfaces* --
+grounds, bands, hairlines, bars, boxes -- take `set rect(..)`,
+`set block(..)`, `set circle(..)` or `set line(..)`; the *type* takes
+`set text(..)` with size, weight, colour, font and tracking. Both act at
+compile time, so the result is the same in the HTML and in the PDF -- with one
+exception: what is only drawn in the PDF, because the browser puts the real
+`<video>` or `<iframe>` in its place, is only seen there. That concerns the
+six labels under /Media and handout/.
+
+#warning[
+  *For the surfaces* the short form works and the long one does not:
+
+  ```typ
+  #show label("ts-slide-progress"): set rect(fill: green)          // yes
+  #show label("ts-slide-progress"): it => { set rect(fill: green); it }   // no
+  ```
+
+  The short form puts the style rule *around* the element it matched, the long
+  one puts it *inside* -- and inside the rectangle there is no second rectangle
+  left for it to reach. Anyone who knows the two spellings as equivalent from
+  other packages runs aground here.
+
+  For the 15 type labels the two spellings are equivalent: what sits inside
+  the matched element there is the text, and a rule reaches that from within
+  as well.
+]
+
+=== Where the rule has to stand
+
+*Before* `#show: presentation`. That one place reaches everything: the slide
+background, the chrome layer with header, footer and progress, the title slide
+and every moving piece.
+
+The `style` hook does *not* reach the same. It is wrapped around the slide
+*body*, and header, footer, progress and the title and section slides are
+built beside it, not inside it. Measured, all 37 rules one at a time: from inside
+`style` exactly the 13 that stand in the slide body take effect -- the
+building blocks `ts-card…`, `ts-callout…`, `ts-statement`, and the three
+stand-in surfaces `ts-media-…`. The other 24 stay silent there, without a
+warning. `style` remains the right place for typography that concerns the
+whole body; for labels, the place before `#show: presentation` is the one.
+
+#warning[
+  A `show` rule written *after* `#show: presentation` does not reach a tracked
+  element (`anim`, `morph`). The reason is the one given under Typography: in
+  the browser every moving piece is typeset a second time in a frame of its
+  own, and that frame never sees a `#show` rule from the document body.
+
+  ```typ
+  #show: presentation.with(theme: themes.default)
+  #show label("ts-statement"): set text(fill: green)   // too late
+  == A slide
+  #statement[still]
+  #anim(statement[moving])
+  ```
+
+  In this file `still` comes out green and `moving` black: four coloured areas
+  in the background, none in the overlay. With the same rule one line further
+  up it is four and six, and both look alike. The PDF does not show the
+  difference, because nothing is typeset twice there.
+
+  This holds for every `#show` rule, not only for label rules; it is not a
+  quirk of the labels.
+]
+
+=== What a label rule changes and what it does not
+
+Reachable is whatever the package does *not* write as an explicit argument.
+For type that is everything; for the surfaces it is `fill` and `stroke`
+everywhere and `radius` wherever the shape has a rounding, because those are
+exactly what typstage gives its shapes through a `set` rule.
+
+`width` stands there as an argument everywhere and is therefore nowhere
+reachable. `height` has three exceptions worth naming: `ts-card`,
+`ts-card-bar` and `ts-callout` get their height as `auto`, and `auto` is not a
+value that could beat a rule. Not in a row of equal height either: measured on
+the painted surface itself, `height:` reaches them there as well.
+
+#show-code[```typ
+#show label("ts-card"): set block(height: 150pt)   // works
+#show label("ts-card"): set block(width: 30%)      // does not
+```]
+
+The first line blows the card up to 150 pt and pushes the callout under it off
+the slide. On the chrome surfaces, the grounds and the handout frame neither
+one does anything; what a `width` rule seems to change there are the blocks
+*inside* the content, see the next box.
+
+The slide's *arrangement* is not reachable either. How tall the header builds,
+how far the rule sits under the title, where the bar goes -- that is produced
+in `place` and `layout` while the layout composes itself, and no `show` rule
+reaches inside it. The theme keys are there for that (`head-gap`,
+`band-height`, `rule-size` and the rest); they stay exactly as they were.
+
+#warning[
+  A rule on `block` or `rect` reaches *inwards*: it holds for the labelled
+  surface and for every block inside it. For `fill`, `stroke` and `radius`
+  that is caught -- the card puts back inside whatever the document had set,
+  or its own colour would run out over the rounded corners. For the spacings
+  it is not caught, and then a label rule moves the slide:
+
+  ```typ
+  #show label("ts-card"): set block(below: 60pt)
+  == A slide
+  #card(title: [Card])[Body]
+  #callout(title: [Note])[Remember this]
+  ```
+
+  Measured with `pdftotext -bbox` on exactly this slide: the callout moves
+  down by 31.2 pt, and everything below it with it. The number is `60pt` minus
+  the block spacing of 1.2 em, at 24 pt text 28.8 pt, *per edge*. Setting
+  `above` and `below` at once, with something above the card, gives both edges
+  and so twice the shift.
+
+  That is not a promise but a side effect of Typst's style rules. Labels are
+  meant for type and surface; for spacings, use the building blocks' own
+  arguments or the theme keys.
+]
+
+=== The complete inventory
+
+What stands here exists; what exists stands here. The names follow one scheme:
+`ts-`, then the *place*, then the *part* -- the part always comes after the
+place, never before. Places are `slide` (the ordinary slide), `title-slide`,
+`section-slide`, `card`, `callout`, `statement`, `media` and `handout`.
+
+Two pairs differ only in word order, and reaching for the wrong one is silent
+-- it simply does nothing. So here they are side by side:
+
+#table(
+  columns: (auto, 1fr),
+  stroke: none,
+  table.header([*Name*], [*Place and part*]),
+  [`ts-slide-title`], [Place `slide`, part `title`: the title of an ordinary
+    slide],
+  [`ts-title-slide-title`], [Place `title-slide`, part `title`: the title of
+    the title slide],
+  [`ts-slide-title-rule`], [Place `slide`: the rule under the slide title],
+  [`ts-title-slide-rule`], [Place `title-slide`: the accent stroke on the
+    title slide],
+)
+
+The mnemonic: `slide` in *front* means the ordinary slide; `slide` behind
+`title` or `section` means that kind of slide.
+
+A label the current theme does not draw -- a header band under
+`header: "run"`, say -- is not on that slide, and a rule on it then does
+nothing.
+
+*The ordinary slide*
+
+#table(
+  columns: (auto, 1fr, auto),
+  stroke: none,
+  table.header([*Label*], [*What it is*], [*Rule*]),
+  [`ts-slide-ground`], [The slide's ground], [`rect`],
+  [`ts-slide-header-band`], [The header band, only under `header: "band"`],
+    [`rect`],
+  [`ts-slide-header-text`], [The running header of number and section, only
+    under `header: "run"`], [`text`],
+  [`ts-slide-header-rule`], [The hairline under it, only under
+    `header: "run"`], [`rect`],
+  [`ts-slide-title`], [The slide title, under all three header styles],
+    [`text`],
+  [`ts-slide-title-rule`], [The rule under the title, only when
+    `rule-size > 0pt`], [`rect`],
+  [`ts-slide-footer`], [The footer line], [`text`],
+  [`ts-slide-number`], [The slide number in it], [`text`],
+  [`ts-slide-footer-rule`], [The hairline above it, only when
+    `footer-rule > 0pt`], [`rect`],
+  [`ts-slide-progress`], [The progress bar, or under `progress: "tick"` the
+    marker that travels], [`rect`],
+  [`ts-slide-progress-track`], [The track it travels along, only under
+    `progress: "tick"`], [`rect`],
+)
+
+*The title slide*
+
+#table(
+  columns: (auto, 1fr, auto),
+  stroke: none,
+  table.header([*Label*], [*What it is*], [*Rule*]),
+  [`ts-title-slide-ground`], [Its ground], [`rect`],
+  [`ts-title-slide-band`], [The band along the top edge, only in
+    `themes.lesson`], [`rect`],
+  [`ts-title-slide-title`], [Its title], [`text`],
+  [`ts-title-slide-subtitle`], [Its subtitle], [`text`],
+  [`ts-title-slide-rule`], [The accent stroke; `themes.editorial` has two,
+    `themes.plain` none], [`rect`],
+  [`ts-title-slide-byline`], [The line of author and date], [`text`],
+)
+
+*The section slide*
+
+#table(
+  columns: (auto, 1fr, auto),
+  stroke: none,
+  table.header([*Label*], [*What it is*], [*Rule*]),
+  [`ts-section-slide-ground`], [Its ground], [`rect`],
+  [`ts-section-slide-bar`], [The bar along the left edge, only in
+    `themes.lesson`], [`rect`],
+  [`ts-section-slide-title`], [Its title], [`text`],
+  [`ts-section-slide-rule`], [The accent stroke; `themes.night` has two,
+    `themes.lesson` none], [`rect`],
+)
+
+A section slide has no subtitle in typstage, so the list names none.
+
+*The building blocks in the body*
+
+#table(
+  columns: (auto, 1fr, auto),
+  stroke: none,
+  table.header([*Label*], [*What it is*], [*Rule*]),
+  [`ts-card`], [The card: surface, border, rounding and all of its contents],
+    [`block`],
+  [`ts-card-bar`], [The coloured tab above it, only under `box: "bar"`],
+    [`block`],
+  [`ts-card-title`], [Its caption], [`text`],
+  [`ts-card-disc`], [The disc of the number, only with `number:`], [`circle`],
+  [`ts-card-number`], [The numeral in it], [`text`],
+  [`ts-card-body`], [Its body], [`text`],
+  [`ts-callout`], [The callout: surface, bar, rounding. The bar on the left is
+    not a label of its own, it is this one's left `stroke` --
+    `set block(stroke: (left: 4pt + red))` recolours it], [`block`],
+  [`ts-callout-title`], [Its caption], [`text`],
+  [`ts-callout-body`], [Its body], [`text`],
+  [`ts-statement`], [The large statement. `size` acts as a factor on it,
+    because `statement` measures in `em`], [`text`],
+)
+
+*Media and handout*
+
+#table(
+  columns: (auto, 1fr, auto),
+  stroke: none,
+  table.header([*Label*], [*What it is*], [*Rule*]),
+  [`ts-media-fallback`], [The box that stands in for a moving element in the
+    PDF. A container only, with no colour and no border of its own, so a
+    `radius` rule on it is not visible while a `fill` rule is], [`block`],
+  [`ts-media-fallback-empty`], [The grey box inside it when no `fallback:` was
+    given. That one does have a surface], [`block`],
+  [`ts-media-poster`], [The grey area of a `video` without a `poster:`],
+    [`rect`],
+  [`ts-handout-frame`], [The framed box of one slide on the handout page],
+    [`block`],
+  [`ts-handout-lines`], [The writing lines beside or below it], [`line`],
+  [`ts-handout-note`], [The speaker note, where there is one], [`text`],
+)
+
+#info[
+  Three things that belong with this.
+
+  *A theme with its own title slide draws none of these labels.*
+  `title-slide` and `section` in a theme are functions and paint their picture
+  themselves; whoever brings their own loses the six respectively four labels
+  of that slide kind, and nothing warns about it. The five bundled ones draw
+  what their picture needs and no more: band and bar exist only in
+  `themes.lesson`, `themes.plain` has no accent stroke on its title slide,
+  `themes.lesson` none on its section slide. Which theme draws what stands in
+  the /What it is/ column.
+
+  *The invisible markers carry none.* Every moving element paints a
+  transparent rectangle around itself so the browser can find it again, and
+  `pin` does the same for a single glyph. That is machinery, not a shape;
+  both stay nameless.
+
+  *Typst labels and the runtime's CSS classes are two separate namespaces.*
+  `.ts-slide` in the stylesheet is a slide's `<section>` in the browser,
+  `ts-slide-title` is a Typst label -- one hyphen apart and unrelated. Typst's
+  HTML export does put a `data-typst-label` attribute on some shapes, on the
+  building blocks of the body for instance, and on the type shapes it does
+  not. That is Typst's own by-product, not a promise of this package: do not
+  build CSS on it.
+]
+
 
 = Handing it on
 

--- a/docs/content-en.typ
+++ b/docs/content-en.typ
@@ -242,14 +242,32 @@ And that is enough to compute the third side from two of them.
 
 `stride: 2` puts two items on each step, `stride: 0` puts all of them on the
 same one. `start` sets the first step, `enter` the motion, `stagger` the delay
-in milliseconds between neighbours, and `spacing` the distance between the
-items.
+in milliseconds between neighbours, `spacing` the distance between the items,
+and `dim` lets each point step back once the next one arrives.
 
 #tip[
   `stagger` also takes several blocks instead of one list. Then each block is
   one step, which is the way to reveal three paragraphs or three pictures in
   turn without writing three `anim` calls.
 ]
+
+`dim: true` turns the sequence into a walk: the point being discussed stands
+there, the ones before it stay legible but muted.
+
+#show-code[```typ
+#stagger(dim: true)[
+  - What the room already knows
+  - What it is about to learn
+  - What it will be able to do afterwards
+]
+```]
+
+For that, each point holds exactly its own step instead of the rest of the
+slide and then rests in `after: "dimmed"` (see "The muted resting state"). Two
+things follow, and both are meant. The last point dims as well as soon as the
+slide has a further step after it, because then the walk has moved on from it
+too. And `stride: 0`, which puts every point on one step, makes them all dim
+together on the next.
 
 == One piece on a step of its own
 
@@ -290,6 +308,76 @@ one after the other.
   a typo in `enter: "fdae-up"` is only noticed by the motion being duller than
   it was meant to be.
 ]
+
+=== The muted resting state
+
+An element whose range has an end goes away afterwards: it plays `exit` and
+keeps the room it had. That is one resting state after the range. `after:
+"dimmed"` gives the second. The point then does not leave. It stays and is
+drawn muted, legible but no longer the thing being talked about.
+
+#show-code[```typ
+#anim(at: "2-3", after: "dimmed")[A passing remark.]
+```]
+
+Nothing moves and nothing is recoloured: the element settles to 65 percent
+opacity and comes back up when you page back. `after` has exactly two values,
+`"hidden"`, the default and what it has always done, and `"dimmed"`.
+
+`after` wants a range that ends. `at: auto` and `at: 3` run to the end of the
+slide, and what never leaves has no after; the package says so as an error
+rather than quietly doing nothing. `at: "3"` is that one step, `at: "2-3"` a
+range.
+
+*On paper `after` does nothing.* A page shows every step at once, and a point
+that is only quiet because the talk has moved past it has no past on a handout.
+This is the rule that already holds for `"hidden"`: what falls out of its range
+in the browser is printed all the same. Printing the HTML page from the browser
+keeps to it too.
+
+*Where the 65 percent comes from.* Opacity composites the ink towards the
+ground, so the ground decides what dimming costs, and on a dark ground it costs
+far less than on a light one. That is a measurement, not an opinion: 0.65 is
+the smallest hundredth at which dimmed body text still reaches the 4.5 to 1
+that this package's contrast contract (see "The contrast contract") asks of
+body text, on all five bundled palettes, upright and inverted, on the paper of
+the slide and on the surface of a card. The tightest of those twenty cases is
+`parchment` on its own paper: 4.57 to 1 at 0.65 and 4.44 at 0.64. The most
+forgiving is `mono` inverted at 8.60. Between full and dimmed there remain 1.94
+to 3.23 to 1 depending on the palette and on whether the element stands on the
+paper or on a card, so the step is plainly visible
+everywhere.
+
+#warning[
+  The guarantee is for text in the `ink` colour, which is what a point is set
+  in. What is already quiet becomes too quiet when dimmed: a line in `muted`
+  measures 2.39 to 4.60 to 1 once dimmed, a word in the accent colour 1.92 to
+  3.03. Dim a point, not a label.
+
+  And opacity mixes with whatever lies behind. The promise is measured against
+  the palette's `paper` and `surface`; over a `card(fill: ...)` of your own or
+  over an image it is not measured and can fall well below. A card in a strong
+  fill was already at 2.73 before dimming and goes to 2.07 with it.
+]
+
+A tracked element *inside* a dimmed one takes the dimming over only if it has
+exactly the same range. That is the same inheritance by which `enter`, `delay`
+and `duration` reach inwards: it applies where both run in lockstep, and not
+otherwise. So an `anim` with a range of its own inside a dimmed `anim` stays at
+full strength, measured on an inner `at: "1-"` inside an outer `at: "1"`.
+
+In practice that puts `morph`, `video`, `embed` and `flipbook` outside the
+inheritance altogether: all four default to `at: "1-"`, an open range, and an
+open range can never match a closed one. Inside a dimmed element they keep
+full strength -- measured, an `embed` stayed at 1.00 while its host went to
+0.65 -- and a formula sitting in a dimmed line stands black in a grey
+sentence. Give the inner element the same closed range by hand, or do not dim
+the line it sits in.
+
+`at:` as a list keeps its usual meaning here. `at: (2, 4)` with
+`after: "dimmed"` shows the element on step 2, takes it away again on step 3,
+brings it back on 4 and rests it dim from 5. The gap in the middle is the list,
+not the dimming.
 
 == Several versions in the same place
 

--- a/docs/content.typ
+++ b/docs/content.typ
@@ -29,6 +29,23 @@ Dieses Handbuch ist nach Vorhaben geordnet, nicht nach Funktionen:
   Die gesetzten Beispiele dieses Handbuchs sind Papier und zeigen deshalb den
   Endzustand -- alles auf einmal. Was im Browser nacheinander geschieht, steht
   im Text daneben oder als Kommentar in der Quelle.
+
+  Jeder `typ`-Block hier wird vor dem Bau der Website gegen das echte Paket
+  übersetzt -- `python3 .github/scripts/pruefe-beispiele.py` --, damit kein
+  Beispiel eine Umbenennung im Paket überlebt, die es ungültig macht. Was der
+  Lauf dabei *nicht* leistet, gehört dazugesagt: Die meisten Blöcke sind
+  Bruchstücke und keine ganzen Dateien, er setzt sie also in eine Folie und
+  prüft, dass sie darin übersetzen -- nicht, dass die Folie danach richtig
+  aussieht. Zeilen, die absichtlich einen Fehler auslösen, sind als solche
+  geführt, müssen fehlschlagen und nennen, woran -- eine Zeile, die aus einem
+  anderen Grund bricht, ist ein durchgefallener Test und kein bestandener. Eine
+  Zeile dagegen, die zwar übersetzt, aber nicht das Gewünschte tut („wirkt
+  nicht", „zu spät"), kann er von einer richtigen nicht unterscheiden. Er
+  übersetzt für den Browser, nicht für Papier, und er sieht nie auf die Prosa
+  neben einem Listing -- dort sitzt eine veraltete Zahl am liebsten. Blöcke in
+  anderen Sprachen bleiben ungeprüft und werden gezählt, damit niemand einen
+  davon durch einen verschriebenen Zaun verliert. Und ein Beispiel, für das ein
+  Begleitpaket fehlt, wird übersprungen; der Lauf sagt, welches.
 ]
 
 = Die erste Präsentation
@@ -41,37 +58,11 @@ Minuten und ohne Umwege.
 Mehr als dies braucht es nicht -- den Import, eine Show-Regel und
 Überschriften. Die folgende Datei ist vollständig und lässt sich abtippen:
 
-#show-code[```typ
-#import "@schule/typstage:0.1.0": *
-
-#show: presentation.with(
-  title: [Der Satz des Pythagoras],
-  subtitle: [Eine Herleitung in vier Schritten],
-  author: [Mathematik · Klasse 9],
-  date: datetime.today(),
-  transition: "slide",
-)
-
-= Worum es geht
-
-== Die Behauptung
-
-#speaker-note[Erst die Zerlegung zeigen, dann die Formel -- nicht umgekehrt.]
-
-#stagger[
-  - Ein rechtwinkliges Dreieck hat zwei Katheten und eine Hypotenuse.
-  - Über jeder Seite steht ein Quadrat.
-  - Die beiden kleinen sind zusammen so groß wie das große.
-]
-
-#v(1em)
-
-#anim(callout[Genau das behauptet der Satz.], enter: "scale")
-
-== Und das ist die Formel
-
-#statement[$ a^2 + b^2 = c^2 $]
-```]
+// Aus der Datei gelesen, nicht abgeschrieben: „vollständig und lässt sich
+// abtippen" ist eine Zusage, und die hält nur, wenn hier dieselben Zeichen
+// stehen, die `.github/scripts/pruefe-beispiele.py` auch übersetzt.
+#show-code(raw(read("../examples/handbuch/erste-praesentation.typ").trim(),
+               block: true, lang: "typ"))
 
 Daraus entstehen vier Folien: die Titelfolie aus `title`, eine Abschnittsfolie
 aus `=`, und je eine gewöhnliche Folie aus den beiden `==`. Der Text bis zur
@@ -274,6 +265,7 @@ Wo die Folien vollständig aus Daten entstehen, lassen sie sich auch einzeln
 übergeben. Dann ist jede Folie ein Funktionsaufruf, und eine Liste von Folien
 lässt sich mit `..` weiterreichen wie jedes andere Array:
 
+// check: dokument
 #show-code[```typ
 #presentation(
   title-slide(title: [Der Satz des Pythagoras], author: [A. Schulz]),
@@ -605,6 +597,7 @@ mehr das, worüber gerade gesprochen wird.
 
 #show-code[```typ
 #anim(at: "2-3", after: "dimmed")[Eine Randbemerkung.]
+#anim(at: 4)[Und weiter im Text.]
 ```]
 
 Nichts bewegt sich dabei, und umgefärbt wird auch nichts: Das Element sinkt auf
@@ -616,6 +609,11 @@ genau zwei Werte, `"hidden"` -- die Vorgabe und das bisherige Verhalten -- und
 Ende der Folie, und was nie geht, hat kein Danach; das Paket sagt das als
 Fehler, statt stillschweigend nichts zu tun. `at: "3"` ist genau dieser eine
 Schritt, `at: "2-3"` ein Bereich.
+
+Und die Folie braucht nach dem Bereich noch einen Schritt -- deshalb steht oben
+die zweite Zeile. Endet der Bereich mit der Folie, gibt es keinen Schritt, auf
+dem das Element gedämpft zu sehen wäre; es verhielte sich genau wie die Vorgabe,
+ohne dass irgendetwas das sagt. Auch das ist ein Fehler beim Übersetzen.
 
 *Auf dem Papier ändert `after` nichts.* Eine Seite zeigt alle Schritte auf
 einmal, und ein Punkt, der nur deshalb leise ist, weil der Vortrag an ihm vorbei
@@ -801,6 +799,7 @@ durchgereicht statt verfolgt (an Leerraum ist ohnehin nichts zu animieren);
 steht es zwischen anderem Inhalt, meldet das Paket einen Fehler, statt die
 Folie stillschweigend verrutschen zu lassen:
 
+// check: folie fehlt=1 weil=fr_spacer_inside_a_tracked_element
 #show-code(```typ
 #anim[Links #v(1fr) Rechts]        // Fehler -- das fr gehört nach draußen
 #anim[Links] #v(1fr) #anim[Rechts] // so ist es gemeint
@@ -852,6 +851,8 @@ Applet aufbauen und Schritt für Schritt weiterbewegen.
 #show-code[```typ
 #import "@schule/typstage:0.1.0": *
 #import "@schule/typstage-geogebra:0.1.0": *
+
+#show: presentation.with(theme: themes.lesson)
 
 == Parametervariation
 
@@ -1009,6 +1010,7 @@ tun.
 `video` legt ein echtes HTML5-Video über die Folie. Beim Betreten der Folie
 läuft es an, beim Verlassen hält es an.
 
+// check: folie dateien=welle.png
 #show-code[```typ
 #video("wellen.mp4", width: 100%, height: 240pt, poster: image("welle.png"))
 ```]
@@ -1114,6 +1116,7 @@ Aufbau auf:
 
 Damit besteht jede Folie der Kette aus zwei Zeilen:
 
+// check: folgen davor
 #show-code[```typ
 == Die Regel am Term -- Schritt 1 von 3
 #umformung(
@@ -1364,6 +1367,7 @@ Seit Typst 0.15 kann eine Übersetzung mehrere Dateien schreiben. Das passt zu
 diesem Paket, denn Vortrag, Foliensatz und Handout unterscheiden sich ohnehin
 nur im Ziel und in einer Angabe. `bundle` schreibt alle drei auf einmal:
 
+// check: dokument ziel=bundle
 #show-code[```typ
 #bundle(
   theme: themes.lesson,
@@ -1525,6 +1529,7 @@ Typst legt keine Dateien an, also müssen die beiden bei `"split"` und beim CDN
 einmal geschrieben werden. Ihr Inhalt steht in `runtime-files`; der
 Bündel-Export gibt sie in demselben Lauf aus, in dem auch der Vortrag entsteht:
 
+// check: ganz ziel=bundle
 #show-code[```typ
 #import "@schule/typstage:0.1.0": *
 
@@ -1785,6 +1790,7 @@ In der Überschriftenschreibweise steht `#invert` im Rumpf der Folie, so wie
 
 In der Argumentschreibweise ist es ein Argument von `slide`:
 
+// check: argument
 #show-code[```typ
 #slide([Erreicht bis 2026], invert: true)[#statement[74 %]]
 ```]
@@ -2109,6 +2115,7 @@ etwas dazwischen läuft so ein Block über den Rand. Im PDF sieht man ihn dort
 noch stehen; im Browser sitzt die Folie in einem Rahmen fester Größe, und was
 darüber hinausragt wird abgeschnitten.
 
+// check: folgen pre=tabelle
 #show-code(```typ
 == Ergebnisse der Regression
 #fit(wrap: false, meine-tabelle)
@@ -2141,6 +2148,7 @@ Eine Tabelle, ein Diagramm oder eine Zeichnung ordnet sich dagegen selbst um,
 wenn man ihr eine schmalere Breite anbietet, und das ändert das Bild statt
 seiner Größe. `wrap: false` misst so einen Block genau so, wie er steht:
 
+// check: folie pre=tabelle
 #show-code(```typ
 #fit(wrap: false, meine-tabelle)
 ```)
@@ -2187,6 +2195,7 @@ ausdrücklich an, dann rechnet das `fit` damit.
   Der Ausweg ist, das `fit` *innerhalb* der Einblendung zu setzen statt darum
   herum:
 
+  // check: folie pre=tabelle fehlt=2 weil=cannot_stand_inside_fit
   ```typ
   #anim(fit(wrap: false, meine-tabelle))   // so
   #fit(anim(meine-tabelle))                // nicht so
@@ -2723,6 +2732,7 @@ und die Antwort ist: nichts. `slide.numbered` sagt, wann das der Fall ist:
 
 Auf einer gewöhnlichen Folie steht sie im Rumpf, also in der Folie selbst:
 
+// check: folgen davor
 #show-code[```typ
 == Eine Folie
 #fusszeile

--- a/docs/content.typ
+++ b/docs/content.typ
@@ -39,8 +39,8 @@ Dieses Handbuch ist nach Vorhaben geordnet, nicht nach Funktionen:
   aussieht. Zeilen, die absichtlich einen Fehler auslösen, sind als solche
   geführt, müssen fehlschlagen und nennen, woran -- eine Zeile, die aus einem
   anderen Grund bricht, ist ein durchgefallener Test und kein bestandener. Eine
-  Zeile dagegen, die zwar übersetzt, aber nicht das Gewünschte tut („wirkt
-  nicht", „zu spät"), kann er von einer richtigen nicht unterscheiden. Er
+  Zeile dagegen, die zwar übersetzt, aber nicht das Gewünschte tut ("wirkt
+  nicht", "zu spät"), kann er von einer richtigen nicht unterscheiden. Er
   übersetzt für den Browser, nicht für Papier, und er sieht nie auf die Prosa
   neben einem Listing -- dort sitzt eine veraltete Zahl am liebsten. Blöcke in
   anderen Sprachen bleiben ungeprüft und werden gezählt, damit niemand einen
@@ -58,7 +58,7 @@ Minuten und ohne Umwege.
 Mehr als dies braucht es nicht -- den Import, eine Show-Regel und
 Überschriften. Die folgende Datei ist vollständig und lässt sich abtippen:
 
-// Aus der Datei gelesen, nicht abgeschrieben: „vollständig und lässt sich
+// Aus der Datei gelesen, nicht abgeschrieben: "vollständig und lässt sich
 // abtippen" ist eine Zusage, und die hält nur, wenn hier dieselben Zeichen
 // stehen, die `.github/scripts/pruefe-beispiele.py` auch übersetzt.
 #show-code(raw(read("../examples/handbuch/erste-praesentation.typ").trim(),
@@ -68,7 +68,7 @@ Daraus entstehen vier Folien: die Titelfolie aus `title`, eine Abschnittsfolie
 aus `=`, und je eine gewöhnliche Folie aus den beiden `==`. Der Text bis zur
 nächsten Überschrift ist der Rumpf einer Folie.
 
-So sieht der Rumpf der Folie „Die Behauptung" aus, wenn alle Schritte
+So sieht der Rumpf der Folie "Die Behauptung" aus, wenn alle Schritte
 abgelaufen sind:
 
 #show-example(
@@ -170,7 +170,7 @@ ist, ob man vor oder hinter dem Plan liegt.
 
 #tip[
   Die Vorschau zeigt den nächsten Schritt, nicht die nächste Folie. Ein Deck,
-  das in Schritten zählt, muss die Frage beantworten „was tut der nächste
+  das in Schritten zählt, muss die Frage beantworten "was tut der nächste
   Tastendruck", und das kann eine neue Folie sein oder eine weitere Enthüllung
   auf derselben. Die Marke darüber sagt, welches von beidem.
 ]
@@ -246,7 +246,7 @@ Stelle sofort zu erreichen.
   erscheint nirgends. Ebenso erreicht ein `#set heading`, das nach der
   Show-Regel steht, die Folientitel nicht mehr -- sie verlassen den Bereich,
   den die Regel umschließt. Für die Typografie der Folien gibt es `style` --
-  siehe das Kapitel „Das eigene Aussehen".
+  siehe das Kapitel "Das eigene Aussehen".
 ]
 
 == Wenn die Folien berechnet werden
@@ -314,13 +314,13 @@ werden soll.
 )
 
 Dazu kommt `tiles` für ein Kachelraster, das sich von selbst staffelt (Kapitel
-„Das eigene Aussehen"), und `morph` für Objekte, die zwischen zwei Folien
-fliegen (Kapitel „Eine Rechnung entwickeln").
+"Das eigene Aussehen"), und `morph` für Objekte, die zwischen zwei Folien
+fliegen (Kapitel "Eine Rechnung entwickeln").
 
 == Der Schrittzeiger
 
 Jede Folie führt einen Schrittzeiger mit. `at` ist vorgabemäßig `auto`, und
-`auto` heißt „der nächste freie Schritt". Aufeinanderfolgende Einblendungen
+`auto` heißt "der nächste freie Schritt". Aufeinanderfolgende Einblendungen
 nummerieren sich damit von selbst; in der Regel steht in einer Folie überhaupt
 keine Zahl.
 
@@ -499,7 +499,7 @@ gesprochen wird, steht da, die vorherigen bleiben lesbar, aber gedämpft.
 ```]
 
 Dafür hält jeder Punkt genau seinen eigenen Schritt statt den Rest der Folie
-und ruht danach in `after: "dimmed"` (siehe „Der gedimmte Ruhezustand"). Zwei
+und ruht danach in `after: "dimmed"` (siehe "Der gedimmte Ruhezustand"). Zwei
 Dinge folgen daraus, und beide sind gewollt: Der letzte Punkt wird ebenfalls
 gedimmt, sobald die Folie nach ihm noch einen Schritt hat -- dann ist der Gang
 auch über ihn hinweg. Und `stride: 0`, das alle Punkte auf einen Schritt legt,
@@ -625,7 +625,7 @@ Papier trotzdem. Der Ausdruck der HTML-Seite aus dem Browser hält es genauso.
 also entscheidet der Untergrund, was das Dimmen kostet -- und auf dunklem Grund
 kostet es deutlich weniger als auf hellem. Das ist eine Messung, keine Meinung:
 0.65 ist der kleinste Hundertstelwert, bei dem gedimmter Fließtext noch die 4,5
-zu 1 erreicht, die der Kontrastvertrag dieses Pakets (siehe „Der
+zu 1 erreicht, die der Kontrastvertrag dieses Pakets (siehe "Der
 Kontrastvertrag") für Fließtext verlangt -- auf allen fünf mitgelieferten
 Paletten, aufrecht wie umgedreht, auf dem Papier der Folie wie auf der Fläche
 einer Karte. Der engste dieser zwanzig Fälle ist `parchment` auf seinem eigenen
@@ -791,7 +791,7 @@ gestaffelten Liste 120 Millisekunden vor seinem eigenen Stichpunkt. Wer etwas
 Eigenes angibt, behält es -- und wer einen anderen Schritt wählt, erbt nichts,
 denn dann sollen die beiden ja gerade nicht zusammen erscheinen.
 
-*Ein `fr`-Abstand gehört nicht ins verfolgte Element.* `fr` heißt „Anteil an
+*Ein `fr`-Abstand gehört nicht ins verfolgte Element.* `fr` heißt "Anteil an
 dem, was übrig bleibt" -- und was übrig bleibt, verteilt der Elternteil unter
 den Geschwistern. Ein verfolgtes Element wird aber allein gemessen und sieht
 seine Geschwister nicht. Ein `#v(1fr)` unmittelbar in einem `anim` wird deshalb
@@ -1001,8 +1001,8 @@ tun.
 
 #warning[
   Beim Zurückblättern und beim Betreten einer Folie wird der ganze Lauf von
-  vorn wiederholt. Aufträge müssen deshalb wiederholbar sein: „setze $a$ auf
-  2,5" ist gut, „erhöhe $a$ um 1" nicht.
+  vorn wiederholt. Aufträge müssen deshalb wiederholbar sein: "setze $a$ auf
+  2,5" ist gut, "erhöhe $a$ um 1" nicht.
 ]
 
 == Video
@@ -1171,7 +1171,7 @@ Rechnung, Zeile für Zeile:
 )
 
 #tip[
-  Die Folientitel der Kette durchzunummerieren („Schritt 2 von 3") kostet
+  Die Folientitel der Kette durchzunummerieren ("Schritt 2 von 3") kostet
   nichts und hilft im Unterricht sofort: Der Fortschrittsbalken zählt Folien,
   nicht Zwischenschritte einer Rechnung.
 ]
@@ -1397,7 +1397,7 @@ hat, obwohl Typst die Introspektion über das ganze Bündel führt.
   experimentell und ohne die Schalter `--features bundle,html` nicht zu haben.
   Und eine Datei, die `bundle` benutzt, lässt sich *nur* mit `--format bundle`
   übersetzen; ein gewöhnliches `typst compile vortrag.typ vortrag.pdf` bricht
-  mit „constructing a document is only supported in the bundle target" ab. Wer
+  mit "constructing a document is only supported in the bundle target" ab. Wer
   beide Wege offenhalten will, legt den Rumpf in ein `#let` und ruft
   `presentation` von Hand.
 ]
@@ -1881,7 +1881,7 @@ Kopfzeile. Wer die Zahlen einhalten will, legt die passende Palette darüber:
 
 #warning[
   *Aus der Füllfarbe wird nicht auf die Schriftfarbe geschlossen.* Ein
-  mattes Salbeigrün wie `#aebdb3` sieht für eine Helligkeitsregel „hell" aus,
+  mattes Salbeigrün wie `#aebdb3` sieht für eine Helligkeitsregel "hell" aus,
   aber Weiß darauf misst 1,96 zu 1 -- weit unter den 4,5, die Fließtext will.
   Deshalb rechnet das Paket mit `contrast` und färbt nirgends automatisch um.
 
@@ -2008,7 +2008,7 @@ Fläche.
   width: 11cm,
 )
 
-`title:` ändert die Überschrift (Vorgabe „Merke"), `color:` die Farbe;
+`title:` ändert die Überschrift (Vorgabe "Merke"), `color:` die Farbe;
 `title: none` lässt sie weg.
 
 === side-by-side -- zwei Spalten
@@ -2251,7 +2251,7 @@ error: assertion failed: typstage: 2 slides run over the room the body has. …
 Shorten the slide, split it, or put the block that does not fit into fit(). …
 ```)
 
-*Warum beim Schritt „at the earliest" steht.* Eine Folie ist auf Schritt eins
+*Warum beim Schritt "at the earliest" steht.* Eine Folie ist auf Schritt eins
 genauso hoch wie auf Schritt fünf: jedes verfolgte Element hält seinen vollen
 Platz von Anfang an mit `hide()`, ob der Rumpf passt, ist also eine Frage an
 die Folie und nicht an den Schritt. Mit dem Schritt ändert sich nur, was
@@ -2701,7 +2701,7 @@ Einblendungen sitzen, denn der Browser setzt nichts neu:
 #alternatives(stand, stand, stand, stand)
 ```]
 
-Das druckt beim Blättern nacheinander „Schritt 1 von 4" bis „Schritt 4 von 4" -- gemessen an einem Prüfstück mit neun Schritten, an jedem einzelnen davon.
+Das druckt beim Blättern nacheinander "Schritt 1 von 4" bis "Schritt 4 von 4" -- gemessen an einem Prüfstück mit neun Schritten, an jedem einzelnen davon.
 
 Auf dem Papier gibt es keinen laufenden Schritt: die Seite zeigt die Folie im
 Endzustand, alles auf einmal. Dort ist `step.number` deshalb gleich
@@ -2785,7 +2785,7 @@ statt sie zu ersetzen.
   ließe sich schließen, indem das Deck seinen Stand am Ende abräumt -- gemessen
   kostet das aber Übersetzungs-Spielraum: eine Folie mit einer Einblendung
   neben einem `tiles` ging damit von null auf drei
-  „did not converge"-Meldungen. Eine Ecke, in der niemand steht, ist das nicht
+  "did not converge"-Meldungen. Eine Ecke, in der niemand steht, ist das nicht
   wert; in der Show-Regel-Form steht hinter dem Deck ohnehin nichts.
 ]
 

--- a/docs/content.typ
+++ b/docs/content.typ
@@ -2120,6 +2120,166 @@ Liste auch keiner.
 ]
 
 
+== `info()`: was das Deck über sich selbst weiß
+
+Labels sagen, wie eine gebaute Form aussieht. Sie sagen nicht, was in ihr
+steht. Die Foliennummer, der Bruch, der Kapitelname in der Kopfzeile -- diese
+Zahlen kannte bisher nur das Paket, und wer eine eigene Fußzeile bauen wollte,
+musste selbst mitzählen. `info()` gibt sie heraus:
+
+#show-code[```typ
+#context {
+  let deck = info()
+  [#deck.section.title #h(1fr) #deck.slide.number / #deck.slide.total]
+}
+```]
+
+Es ist dieselbe Lesung, die die eingebaute Fußzeile macht. Jede Zahl, die das
+Paket auf eine Folie druckt -- die Foliennummer, der Bruch, die Länge des
+Fortschrittsbalkens, die laufende Kopfzeile --, kommt aus diesem Wörterbuch und
+aus keiner zweiten Zählung. Eine selbstgebaute Fußzeile und die eingebaute
+können deshalb nicht verschiedene Zahlen drucken.
+
+Was zurückkommt:
+
+#table(
+  columns: (auto, 1fr),
+  stroke: 0.5pt + luma(180),
+  table.header([*Feld*], [*Was darin steht*]),
+  [`title`, `subtitle`], [Titel und Untertitel des Decks, so wie
+    `presentation` oder eine `title-slide` sie bekommen haben],
+  [`author`, `date`], [Ebendaher. `date` ist, was übergeben wurde: ein
+    `datetime` oder Inhalt],
+  [`slide.number`], [Diese Folie. Gezählt wie die Fußzeile zählt, Titel- und
+    Abschnittsfolien also nicht mit],
+  [`slide.total`], [So viele Folien werden gezählt],
+  [`slide.numbered`], [Ob diese Folie mitgezählt wird. Auf einer Titel- oder
+    Abschnittsfolie `false`],
+  [`step.number`], [Der Schritt, auf dem der aufrufende Inhalt selbst steht],
+  [`step.total`], [So viele Schritte hat diese Folie],
+  [`section.number`], [Der wievielte Abschnitt gerade läuft, `0` vor dem
+    ersten],
+  [`section.total`], [So viele Abschnitte hat das Deck],
+  [`section.title`], [Sein Titel, oder `none` vor dem ersten],
+)
+
+Eine Zahl steht bewusst daneben: Sprecheransicht und Übersicht zählen *alle*
+Folien, Titel- und Abschnittsfolien eingeschlossen, `info().slide.total` zählt
+wie die Fußzeile und lässt sie aus. Auf einem Prüfstück mit einer Titelfolie,
+zwei Abschnittsfolien und drei gewöhnlichen sind das 6 gegen 3.
+
+=== Zwei Zählungen, nicht eine
+
+Ein Deck, das Seiten zählt, käme mit einer Zahl aus. Dieses zählt in Folien
+*und* in Schritten, und die beiden sind verschiedene Dinge: eine Folie ist ein
+Bild, ein Schritt ist ein Tastendruck. Deshalb stehen sie getrennt und heißen
+so, wie sie im ganzen Handbuch heißen.
+
+`step.number` ist der Schritt, auf dem der aufrufende Inhalt selbst steht: im
+Rumpf einer Folie `1`, innerhalb eines `anim`, eines `stagger` oder einer
+`alternatives` der Schritt jener Einblendung -- und wo eine Einblendung über
+mehrere Schritte steht, ihr erster. Das ist der Unterschied, auf den
+es ankommt -- eine Anzeige, die den laufenden Schritt nennt, muss in den
+Einblendungen sitzen, denn der Browser setzt nichts neu:
+
+#show-code[```typ
+#let stand = context {
+  let d = info()
+  [Schritt #d.step.number von #d.step.total]
+}
+
+== Vier Fassungen
+#alternatives(stand, stand, stand, stand)
+```]
+
+Das druckt beim Blättern nacheinander „Schritt 1 von 4" bis „Schritt 4 von 4" -- gemessen an einem Prüfstück mit neun Schritten, an jedem einzelnen davon.
+
+Auf dem Papier gibt es keinen laufenden Schritt: die Seite zeigt die Folie im
+Endzustand, alles auf einmal. Dort ist `step.number` deshalb gleich
+`step.total`.
+
+#info[
+  `step.total` zählt dasselbe wie die Laufzeit im Browser. Gegengeprüft an
+  einem Deck, das jeden Baustein einmal enthält, der einen Schritt verbraucht
+  -- `pause`, `stagger`, `anim` mit und ohne Nummer, `alternatives`, `tiles`,
+  `morph`, `video`, `flipbook`: auf allen neun Folien mit Rumpf nennt `info()`
+  dieselbe Zahl, die die Laufzeit im Browser zählt, und die PDF nennt sie
+  ebenfalls.
+]
+
+=== Wohin die eigene Fußzeile gehört
+
+Auf einer Titel- oder Abschnittsfolie zeichnet typstage keine Fußzeile. Wer
+eine eigene baut, steht dort vor der Frage, was in den Zahlenplatz gehört --
+und die Antwort ist: nichts. `slide.numbered` sagt, wann das der Fall ist:
+
+#show-code[```typ
+#let fusszeile = context {
+  let d = info()
+  let zahl = if d.slide.numbered [#d.slide.number / #d.slide.total] else []
+  place(bottom + right, text(size: 12pt, fill: muted, zahl))
+}
+```]
+
+Auf einer gewöhnlichen Folie steht sie im Rumpf, also in der Folie selbst:
+
+#show-code[```typ
+== Eine Folie
+#fusszeile
+Der Text der Folie.
+```]
+
+Auf der Titel- und den Abschnittsfolien muss sie ins Theme: die beiden Bilder
+sind Funktionen, und eine Funktion, die eine andere umschließt, ergänzt sie,
+statt sie zu ersetzen.
+
+#show-code[```typ
+#let basis = themes.default
+#let mit(f) = (t, s, geo) => { f(t, s, geo); fusszeile }
+
+#show: presentation.with(
+  theme: basis + (title-slide: mit(basis.title-slide), section: mit(basis.section)),
+)
+```]
+
+#warning[
+  *Nicht über `style:`.* Der Haken sieht nach der bequemen Abkürzung aus:
+  `style: it => { fusszeile; it }` schriebe die Fußzeile auf jede Folie, ohne
+  sie einzeln hinzuschreiben. Er ist aber zugleich die Vorlage, mit der jedes
+  bewegte Element ein zweites Mal gesetzt wird -- und alles, was dort
+  *zeichnet*, wird in jedem Sprite mitgezeichnet.
+
+  Gemessen an einem Deck mit drei Einblendungen je Folie: die Fußzeile stand
+  im Browser viermal auf der Folie statt einmal, und in einem Daumenkino aus
+  sechs Einzelbildern noch sechsmal zusätzlich. Im Rumpf gezählt, dasselbe
+  Deck, dieselben Sprites: einmal. Auf dem Papier fällt es nicht auf, dort gibt
+  es keine Sprites.
+
+  `style:` ist für Typografie da -- Schrift, Größe, Farbe, Zeilenabstand --,
+  und dafür ist es genau richtig: Hintergrund und Sprite brauchen dieselbe.
+]
+
+#info[
+  Eine im Rumpf platzierte Fußzeile sitzt am unteren Rand des *Rumpfes*, nicht
+  am unteren Rand der Folie; dazwischen liegt der `foot-gap` des Themes. Ein
+  `dy:` am `place` schiebt sie dorthin, wo sie hin soll.
+]
+
+#warning[
+  `info()` liest den Stand der Folie, die gerade gesetzt wird, und braucht
+  deshalb ein `context` um sich. *Vor* der Präsentation gibt es nichts zu
+  lesen; dort bricht es mit einer Meldung ab, statt Nullen zu liefern.
+
+  *Danach* nicht: wer die Folien als Argumente übergibt und unter den Aufruf
+  noch ein `info()` schreibt, bekommt weiter die Zahlen der letzten Folie. Das
+  ließe sich schließen, indem das Deck seinen Stand am Ende abräumt -- gemessen
+  kostet das aber Übersetzungs-Spielraum: eine Folie mit einer Einblendung
+  neben einem `tiles` ging damit von null auf drei
+  „did not converge"-Meldungen. Eine Ecke, in der niemand steht, ist das nicht
+  wert; in der Show-Regel-Form steht hinter dem Deck ohnehin nichts.
+]
+
+
 = API-Referenz
 
 Erzeugt aus den Kommentaren der Quelldateien. Die Reihenfolge folgt dem Aufbau

--- a/docs/content.typ
+++ b/docs/content.typ
@@ -1911,6 +1911,104 @@ Die Rechnung dahinter ist von mosaic übernommen, das sie aus Touying 0.7.4
 übernommen hat; Touying schreibt die Arbeit daran Andreas Kröpelin
 (Polylux PR #91) und ntjess zu.
 
+=== overflow -- der Prüflauf vor dem Vortrag
+
+`fit` beantwortet den einen Block, dessen Größe man schon ahnt. `overflow`
+beantwortet die Frage, die man nicht Folie für Folie stellen kann: läuft
+irgendwo in diesem Deck etwas über seinen Platz? Es misst jeden Folienrumpf
+gegen den Platz, den das Theme ihm gibt, und nennt die, die nicht hineingehen.
+
+#show-code(```typ
+#show: presentation.with(overflow: "error")
+```)
+
+Standardmäßig aus, und dafür gedacht, für einen Lauf eingeschaltet zu werden --
+nicht dafür, beim Schreiben mitzulaufen.
+
+Ein Foliensatz braucht das dringender als ein Dokument. Auf einer Seite, die
+man durchblättert, sieht man den Überlauf: die Zeile steht schlicht über dem
+Rand und das Auge fängt sie. Eine typstage-Folie wird in einen SVG-Rahmen
+fester Größe gesetzt und im Browser skaliert -- was übersteht, wird
+abgeschnitten oder neben die Folie gezeichnet, und einen Vortrag, den man
+durchklickt, sieht man darauf erst am Beamer.
+
+/ `"none"`: es wird nichts gemessen. Der Vorgabewert.
+/ `"error"`: das ganze Deck wird gebaut, und dann bricht es mit *allen* Stellen
+  auf einmal ab statt mit der ersten. Ein Lauf, die ganze Liste.
+/ `"record"`: es baut durch und legt stattdessen je Fund einen abfragbaren
+  Datensatz ab, für ein Werkzeug oder ein Bauskript. Typst gibt einem Paket
+  keinen Warnkanal, `"record"` gibt von sich aus also nichts aus.
+
+Die Meldung nennt Folie, Schritt und das Maß (hier gekürzt, der Fließtext um
+die Liste herum ist weggelassen):
+
+#show-code(```
+error: assertion failed: typstage: 2 slides run over the room the body has. …
+  slide 2, from step 1 at the earliest: 311.14pt too tall, 675.76pt of content in 364.61pt of room
+  slide 3, from step 2 at the earliest: 296.49pt too tall, 661.1pt of content in 364.61pt of room
+Shorten the slide, split it, or put the block that does not fit into fit(). …
+```)
+
+*Warum beim Schritt „at the earliest" steht.* Eine Folie ist auf Schritt eins
+genauso hoch wie auf Schritt fünf: jedes verfolgte Element hält seinen vollen
+Platz von Anfang an mit `hide()`, ob der Rumpf passt, ist also eine Frage an
+die Folie und nicht an den Schritt. Mit dem Schritt ändert sich nur, was
+*gezeichnet* wird. Ein `anim`, das unten übersteht, ist bis zu seinem Schritt
+unsichtbar, und erst dann gibt es etwas zu sehen.
+
+Der Schritt wird aus den Einblendungen gerechnet: alles, was erst nach Schritt
+k dazukommt, ist dort unsichtbar, und ist der Überlauf größer als das alles
+zusammen, hängt schon auf Schritt k etwas über den Rand. Das ist eine untere
+Schranke und keine genaue Antwort, denn die Summe zählt die Einblendungen und
+sonst nichts -- die Zwischenräume, Blockabstand, ein `v()`, zählen in der Höhe
+des Rumpfes und in keiner Einblendung. Gemessen: ein 350 pt hoher Kasten, ein
+`v(100pt)` und ein `anim(at: 4)` darunter werden ab Schritt 1 gemeldet, während
+der Überstand erst auf Schritt 4 auf den Schirm kommt. Wo das Überstehende
+selbst eine Einblendung ist und nichts Leeres darüber steht, stimmt der Schritt
+genau: `anim(at: 3)` wird ab Schritt 3 gemeldet. *Die Folie steht in beiden
+Fällen richtig da*, und das ist der Teil, an dem man handelt. Auf Papier wird
+gar kein Schritt genannt, weil dort jeder Schritt zugleich auf der Seite steht;
+in den Datensätzen zeigt sich das als `step: 0`.
+
+Die Datensätze holt man mit `typst eval`, und dafür muss das Deck auf
+`overflow: "record"` stehen -- auf `"error"` bricht auch dieser Befehl mit dem
+Fehler ab:
+
+#show-code(```sh
+typst eval --target html --features html --in deck.typ \
+  'query(<typstage-overflow>).map(e => e.value)'
+```)
+
+und bekommt je Fund einen Eintrag:
+
+#show-code(```json
+[{"slide":2,"step":1,"height":675.76,"room":364.61,"over":311.14},
+ {"slide":3,"step":2,"height":661.1,"room":364.61,"over":296.49}]
+```)
+
+#info[
+  *Was die Prüfung nicht sieht.* Gemessen wird nur die Höhe. `measure` deckelt
+  auch die Breite, die es meldet, bei der Breite, die es bekommt -- ein zu
+  breiter Rumpf ist also nicht von einem zu unterscheiden, der seine Spalte
+  füllt. Für diesen Fall ist `fit` die Antwort, und beide gehören zusammen: die
+  Prüfung findet die Folie, `fit` richtet den Block.
+
+  Viererlei wird übersehen statt gemeldet. Ein `height: 100%` im Rumpf misst 0,
+  ein `1fr` fällt zusammen. Alles, was außerhalb seines eigenen Layoutkastens
+  zeichnet -- `scale`, `move`, `place` mit Versatz --, ist für eine Messung
+  unsichtbar. Und Titel- und Abschnittsfolien werden nie gemessen: das Theme
+  zeichnet sie mit `place`, sie haben keinen Rumpfblock, über den etwas laufen
+  könnte.
+
+  Einerlei wird gemeldet, wo nichts zu sehen ist: nachlaufender Abstand, ein
+  `v()` am Ende eines Rumpfes, nimmt in der Messung Platz und zeichnet nichts.
+]
+
+Gemessen über die sechs Beispieldecks: in der HTML kostet der Lauf merklich
+mehr Zeit, je nach Deck und Verrechnung des Prozessstarts zwischen dem 1,2- und
+dem 1,5-Fachen; auf Papier kostet er wenig, ein paar Millisekunden je Deck.
+Über alle sechs Decks gelaufen meldet er nichts -- keines von ihnen läuft über.
+
 === Folien ohne Titel
 
 Ein nacktes `==` lässt den Titelbalken weg; der Rumpf beginnt dann oben und

--- a/docs/content.typ
+++ b/docs/content.typ
@@ -491,7 +491,27 @@ Argumente staffeln beliebige Blöcke nach denselben Regeln:
                 (Vorgabe 60)],
   [`enter`], [Bewegung der Punkte, wie bei `anim`],
   [`spacing`], [Abstand zwischen den Zeilen (Vorgabe 0.65 em)],
+  [`dim`], [`true` lässt jeden Punkt gedämpft stehenbleiben, sobald der
+            nächste kommt (Vorgabe `false`)],
 )
+
+`dim: true` macht aus der Staffelung einen Gang: Der Punkt, über den gerade
+gesprochen wird, steht da, die vorherigen bleiben lesbar, aber gedämpft.
+
+#show-code[```typ
+#stagger(dim: true)[
+  - Was der Raum schon weiß
+  - Was er gleich lernt
+  - Was er danach kann
+]
+```]
+
+Dafür hält jeder Punkt genau seinen eigenen Schritt statt den Rest der Folie
+und ruht danach in `after: "dimmed"` (siehe „Der gedimmte Ruhezustand"). Zwei
+Dinge folgen daraus, und beide sind gewollt: Der letzte Punkt wird ebenfalls
+gedimmt, sobald die Folie nach ihm noch einen Schritt hat -- dann ist der Gang
+auch über ihn hinweg. Und `stride: 0`, das alle Punkte auf einen Schritt legt,
+lässt sie gemeinsam auf dem nächsten dimmen.
 
 `stride: 0` und `stagger` gehören zusammen: Alle Punkte erscheinen dann auf
 einem einzigen Schritt, aber kurz nacheinander eingeschwenkt -- eine Welle
@@ -574,6 +594,82 @@ Selektor ein Ende hat.
 (`duration:` auf `presentation`, 520). `delay` ist 0. Beide sind Zahlen in
 Millisekunden und gelten für den Auftritt; beim Zurückblättern entfällt die
 Verzögerung, damit der Rückweg nicht zäh wird.
+
+=== Der gedimmte Ruhezustand
+
+Ein Element, dessen Bereich ein Ende hat, verschwindet danach: Es blendet mit
+`exit` aus und behält den Platz, den es hatte. Das ist der eine Ruhezustand
+nach dem Bereich. `after: "dimmed"` gibt den zweiten. Dann geht der Punkt nicht
+weg, sondern bleibt stehen und wird gedämpft gezeichnet -- lesbar, aber nicht
+mehr das, worüber gerade gesprochen wird.
+
+#show-code[```typ
+#anim(at: "2-3", after: "dimmed")[Eine Randbemerkung.]
+```]
+
+Nichts bewegt sich dabei, und umgefärbt wird auch nichts: Das Element sinkt auf
+65 Prozent Deckkraft und kommt beim Zurückblättern wieder herauf. `after` hat
+genau zwei Werte, `"hidden"` -- die Vorgabe und das bisherige Verhalten -- und
+`"dimmed"`.
+
+`after` braucht einen Bereich, der endet. `at: auto` und `at: 3` laufen bis zum
+Ende der Folie, und was nie geht, hat kein Danach; das Paket sagt das als
+Fehler, statt stillschweigend nichts zu tun. `at: "3"` ist genau dieser eine
+Schritt, `at: "2-3"` ein Bereich.
+
+*Auf dem Papier ändert `after` nichts.* Eine Seite zeigt alle Schritte auf
+einmal, und ein Punkt, der nur deshalb leise ist, weil der Vortrag an ihm vorbei
+ist, hat auf einem Handout kein Vorbei. Das ist dieselbe Regel, die für
+`"hidden"` längst gilt: Was im Browser aus seinem Bereich fällt, steht auf dem
+Papier trotzdem. Der Ausdruck der HTML-Seite aus dem Browser hält es genauso.
+
+*Woher die 65 Prozent kommen.* Deckkraft mischt die Schrift zum Untergrund hin,
+also entscheidet der Untergrund, was das Dimmen kostet -- und auf dunklem Grund
+kostet es deutlich weniger als auf hellem. Das ist eine Messung, keine Meinung:
+0.65 ist der kleinste Hundertstelwert, bei dem gedimmter Fließtext noch die 4,5
+zu 1 erreicht, die der Kontrastvertrag dieses Pakets (siehe „Der
+Kontrastvertrag") für Fließtext verlangt -- auf allen fünf mitgelieferten
+Paletten, aufrecht wie umgedreht, auf dem Papier der Folie wie auf der Fläche
+einer Karte. Der engste dieser zwanzig Fälle ist `parchment` auf seinem eigenen
+Papier: 4,57 zu 1 bei 0.65 und 4,44 bei 0.64. Der großzügigste ist `mono`
+umgedreht mit 8,60. Zwischen voll und gedimmt bleiben je nach Palette
+1,94 bis 3,23 zu 1 -- je nach Palette und danach, ob das Element auf dem
+Papier oder auf einer Karte steht; der Unterschied ist also überall deutlich
+zu sehen.
+
+#warning[
+  Die Zusage gilt für Text in der Schriftfarbe `ink`, und das ist, worin ein
+  Stichpunkt gesetzt ist. Was schon leise ist, wird durch Dimmen zu leise: eine
+  Zeile in `muted` misst gedimmt 2,39 bis 4,60 zu 1, ein Wort in der
+  Akzentfarbe 1,92 bis 3,03. Gedimmt gehört ein Stichpunkt, keine Beschriftung.
+
+  Und Deckkraft mischt zu dem, was dahinterliegt. Die Zusage ist gegen `paper`
+  und `surface` der Palette gemessen; über einer eigenen `card(fill: ...)` oder
+  über einem Bild ist sie es nicht und kann deutlich darunter fallen. Eine
+  Karte in kräftiger Füllung lag schon vor dem Dimmen bei 2,73 und geht mit
+  ihm auf 2,07.
+]
+
+Ein verfolgtes Element *innerhalb* eines gedimmten übernimmt das Dimmen nur,
+wenn es genau denselben Bereich hat. Das ist dieselbe Vererbung, nach der auch
+`enter`, `delay` und `duration` von außen nach innen gelten: Sie greift, wenn
+beide im Gleichschritt laufen, und sonst nicht. Ein `anim` mit eigenem Bereich
+in einem gedimmten `anim` bleibt also voll stehen -- gemessen an einem inneren
+`at: "1-"` in einem äußeren `at: "1"`.
+
+In der Praxis stehen `morph`, `video`, `embed` und `flipbook` damit ganz
+außerhalb dieser Vererbung: alle vier haben `at: "1-"` als Vorgabe, einen
+offenen Bereich, und ein offener kann zu einem geschlossenen nie passen. In
+einem gedimmten Element bleiben sie voll stehen -- gemessen blieb ein `embed`
+bei 1,00, während sein Wirt auf 0,65 ging --, und eine Formel in einer
+gedimmten Zeile steht schwarz in einem grauen Satz. Wer das nicht will, gibt
+dem inneren Element von Hand denselben geschlossenen Bereich oder dimmt die
+Zeile nicht.
+
+`at:` als Aufzählung behält hier seine gewohnte Bedeutung. `at: (2, 4)` mit
+`after: "dimmed"` zeigt das Element auf Schritt 2, nimmt es auf 3 wieder weg,
+bringt es auf 4 zurück und lässt es ab 5 gedimmt stehen. Die Lücke in der
+Mitte macht die Aufzählung, nicht das Dimmen.
 
 == Mehrere Fassungen an derselben Stelle
 

--- a/docs/content.typ
+++ b/docs/content.typ
@@ -1360,6 +1360,12 @@ Im Handout steht dieselbe Notiz bei ihrer Folie. Eine Notiz erfüllt damit zwei
 Zwecke auf einmal: Gedächtnisstütze beim Vortrag und Erläuterung auf dem Blatt,
 das die Klasse mitnimmt.
 
+Eine Notiz muss Text tragen. Die Sprecheransicht befördert sie als
+Zeichenkette, und das Handout druckt sie dort, wo Text darin steht -- eine
+Notiz, die nur aus Layout besteht (ein `fit`, ein blankes `rect`, ein Bild),
+käme also nirgends an. Das wird mit einer Meldung abgewiesen statt still
+verschluckt. Was *gesehen* werden soll, gehört auf die Folie.
+
 == Was auf dem Papier fehlt -- und was man dafür vorsieht
 
 #table(
@@ -1658,7 +1664,7 @@ Haken `style`: eine Funktion, die um jeden Folienrumpf gelegt wird.
 
 == Bausteine für den Folienrumpf
 
-Fünf Bausteine für den Rumpf. Es sind Inhaltsfunktionen, keine eigenen
+Sechs Bausteine für den Rumpf. Es sind Inhaltsfunktionen, keine eigenen
 Folienarten -- sie lassen sich schachteln, in eine Rasterzelle setzen und mit
 `anim` einblenden.
 
@@ -1801,6 +1807,109 @@ Schritten:
 `statement` fordert ausdrücklich die volle Breite an und zentriert darin --
 genau das, woran ein blankes `align(center, …)` in einem verfolgten Element
 scheitert.
+
+=== fit -- den Inhalt auf seinen Platz rechnen
+
+Für das eine Stück, dessen Größe nicht im Deck steht: die breite Tabelle aus
+der Auswertung, das erzeugte Diagramm, die Liste aus einer Datendatei. Ohne
+etwas dazwischen läuft so ein Block über den Rand. Im PDF sieht man ihn dort
+noch stehen; im Browser sitzt die Folie in einem Rahmen fester Größe, und was
+darüber hinausragt wird abgeschnitten.
+
+#show-code(```typ
+== Ergebnisse der Regression
+#fit(wrap: false, meine-tabelle)
+```)
+
+`wrap: false`, weil der Block eine Tabelle ist. Alles, was sich selbst in
+Spalten setzt, will so gemessen werden, wie es steht; der Grund steht zwei
+Absätze weiter, und es ist die eine Angabe, die man vor dem ersten Gebrauch
+kennen sollte.
+
+`fit` misst den Block gegen den Platz, an dem er steht, und skaliert ihn
+geometrisch: die Verhältnisse bleiben, ein Faktor von Hand entfällt. Gemessen
+an einer Tabelle mit 9 Spalten und 22 Datenzeilen: der Rumpf einer Folie im Theme
+`plain` ist 777,89 pt breit und 364,61 pt hoch, die Tabelle misst
+572,09 pt #sym.times 571,60 pt, ist also 207 pt zu hoch. `fit` rechnet mit
+63,8 % und setzt sie 364,6 pt hoch. In der HTML und im PDF gleichermaßen, denn
+gerechnet wird beim Übersetzen.
+
+*Erst die Breite anbieten, dann verkleinern.* Der Block bekommt die volle
+Breite angeboten, bevor gemessen wird. Ein Absatz oder eine Liste bricht dann
+um, statt zu schrumpfen, und nur was danach noch zu hoch ist, wird skaliert.
+Gemessen an `lorem(60)`: frei gesetzt ist der Absatz eine einzige Zeile von
+3490 pt, in der angebotenen Breite des Rumpfes
+777,89 pt #sym.times 111,06 pt und passt damit bereits. Der Faktor kommt auf
+100 %, `fit` rührt den Absatz nicht an, und die Folie mit `fit` und die ohne
+sind im Absatzbereich pixelgleich. Ohne das Angebot der Breite käme derselbe
+Absatz auf 22,3 % und stünde als Fadenzeile über der Folie.
+
+Eine Tabelle, ein Diagramm oder eine Zeichnung ordnet sich dagegen selbst um,
+wenn man ihr eine schmalere Breite anbietet, und das ändert das Bild statt
+seiner Größe. `wrap: false` misst so einen Block genau so, wie er steht:
+
+#show-code(```typ
+#fit(wrap: false, meine-tabelle)
+```)
+
+Gemessen an einer Tabelle mit 24 Spalten, die frei gesetzt 1316 pt breit ist:
+mit dem Vorgabewert `wrap: true` quetscht Typst die Spalten in die 777,89 pt
+des Rumpfes, die Ziffern überlagern sich, und der Faktor kommt bei 100 %
+heraus, es wird also nichts skaliert. Mit `wrap: false` rechnet `fit` mit
+59,1 %, und die Spalten behalten ihr Verhältnis.
+
+*Es verkleinert nur.* `grow: true` bläst auch auf, was kleiner ist als sein
+Platz -- für die eine große Zahl, die die Folie füllen soll. `shrink: false`
+nimmt das Verkleinern weg und lässt nur das Vergrößern übrig.
+
+#show-code(```typ
+#fit(grow: true)[42%]
+```)
+
+`width` und `height` nehmen `auto`, eine Länge oder einen Anteil. Bei
+`height: auto` nimmt sich der Block, was unter dem übrigen Inhalt der Folie
+übrig bleibt; ein `fit` unter zwei Stichpunkten rechnet also mit den
+Stichpunkten. Das hat eine Kehrseite, sobald etwas das `fit` umschließt: in
+einem `card` wird der Kasten folienhoch, unten abgeschnitten, und *was nach
+dem `card` steht, fällt von der Folie* -- in beiden Ausgaben gemessen. Das tut
+das `1fr`, nicht das Skalieren: ein `card` um ein blankes
+`block(height: 1fr)` verhält sich genauso. In einem `card` gibt man `height:`
+ausdrücklich an, dann rechnet das `fit` damit.
+
+#warning[
+  *Keine Einblendung im `fit`.* Zweierlei übersteht das Messen nicht. Ein
+  `pause` wird gefunden, indem der Folienrumpf abgelaufen wird, und ein
+  gemessener Block ist eine Closure, in die dieser Lauf nicht hineinkommt:
+  gemessen an einer Folie mit zwei Pausen fiel die Schrittzahl von drei auf
+  eins, und nichts hat es gesagt. Und ein gemessener Block hat keine Höhe, gegen
+  die er rechnen könnte -- die Breite ist die, die ein umbrechendes `fit`
+  hineinreicht, die Höhe aber kommt unbegrenzt zurück, und genau an dieser
+  Achse legt ein verfolgtes Element seine Größe und den Platz seiner Marke
+  fest. Gemessen: ein `anim` in einem `fit` wurde gar nicht verkleinert und
+  lief unten aus der Folie.
+
+  `fit` bricht deshalb ab, mit Namen und Rat, für `pause`, `anim`, `stagger`,
+  `alternatives`, `morph`, `tiles`, `video`, `embed` und `flipbook` -- in
+  beiden Ausgaben und auch dann, wenn das `fit` in einem anderen `fit` steckt.
+  Der Ausweg ist, das `fit` *innerhalb* der Einblendung zu setzen statt darum
+  herum:
+
+  ```typ
+  #anim(fit(wrap: false, meine-tabelle))   // so
+  #fit(anim(meine-tabelle))                // nicht so
+  ```
+]
+
+`speaker-note` und `bridge-job` dürfen im `fit` stehen. Sie legen keine
+Geometrie fest, und eine Messung schreibt keinen Zustand fest, beide kommen
+also nachgemessen genau einmal an. Die andere Richtung ist die, die nicht
+geht: eine Notiz, die nur aus einem `fit` besteht, trägt keinen Text und
+erreicht damit weder die Sprecheransicht noch das Handout. `speaker-note`
+weist das mit einer Meldung ab.
+
+Die Rechnung dahinter ist von mosaic übernommen, das sie aus Touying 0.7.4
+übernommen hat; Touying schreibt die Arbeit daran Andreas Kröpelin
+(Polylux PR #91) und ntjess zu.
 
 === Folien ohne Titel
 

--- a/docs/content.typ
+++ b/docs/content.typ
@@ -1547,11 +1547,85 @@ dunkel, `head-gap`, `foot-gap` und `band-height` für die Luft um den Rumpf --
 und `title-slide` und `section`, die ganze Bilder sind: Funktionen
 `(t, s, geo) => content`. Die vollständige Liste steht in der API-Referenz.
 
+== Eine Palette wählen
+
+Ein Theme sagt, wie eine Folie *gebaut* ist; eine *Palette* sagt, welche Farbe
+sie hat. Beides ändert sich unabhängig voneinander: der Unterrichtsentwurf ist
+auch im abgedunkelten Raum noch der Unterrichtsentwurf. Deshalb nimmt
+`presentation` die Palette getrennt entgegen, und sie überschreibt
+*teilweise* -- nur die Einträge, die dastehen:
+
+#show-code[```typ
+#show: presentation.with(theme: themes.lesson, palette: (accent: blue))
+#show: presentation.with(theme: themes.lesson, palette: palettes.dark)
+```]
+
+Eine Palette trägt acht Einträge, und es sind genau die Farbeinträge eines
+Themes: `paper` der Grund der Folie, `ink` der Fließtext, `strong` die
+tragende dunkle Farbe, `accent` die Signalfarbe, `muted` das Nebensächliche,
+`surface` der Grund einer Karte, `border` deren Kante und `inverted`, ob heller
+Satz auf dunklem Grund steht. Ein Eintrag, den es nicht gibt, wird abgewiesen:
+`palette: (acent: blue)` bricht mit einer Meldung ab, statt still nichts zu
+tun.
+
+Fünf Paletten sind mitgeliefert. Jede läuft mit jedem der fünf Themes:
+
+#table(
+  columns: (auto, 1fr),
+  stroke: 0.5pt + luma(180),
+  table.header([*Palette*], [*Woher*]),
+  [`palettes.light`], [Genau die Farben von `themes.default`. Diese Palette
+    ändert an der Vorgabe nichts.],
+  [`palettes.mono`], [Das Grau von `themes.plain`, zwei Töne verschoben,
+    damit es den Vertrag unten besteht.],
+  [`palettes.textbook`], [Die am Schulbuch gemessenen Farben von
+    `themes.lesson`, ein Grau verschoben.],
+  [`palettes.parchment`], [Das Werkdruckpapier von `themes.editorial`, zwei
+    Töne verschoben.],
+  [`palettes.dark`], [Der dunkle Grund von `themes.night`, mit einem
+    tieferen Akzent.],
+)
+
+Daraus folgt der Satz, der sonst ein eigenes Theme kostet: *ein weiteres
+dunkles Theme braucht es nicht, weil Dunkelheit eine Palette ist und keine
+Gestaltung.* `themes.lesson` mit `palettes.dark` ist weiterhin der
+Unterrichtsentwurf, nur dunkel.
+
+`themes.night` bleibt trotzdem ein Theme, und der Grund ist gemessen. Sein
+Zyan `#5ec8f2` trägt die Überschrift auf dem eigenen Grund mit 9,77 zu 1 und
+auf dem Grund, den eine umgedrehte Folie dahinterlegt, mit 1,59. Eine Farbe,
+die auf beiden hält, müsste bei etwa 0,13 bis 0,23 relativer Leuchtdichte
+liegen; das Zyan liegt bei 0,52. Also nimmt `palettes.dark` ein tieferes Blau,
+das auf beiden hält, und `themes.night` behält das Zyan, um das herum es
+entworfen wurde.
+
+#warning[
+  Zwei Farben eines Themes sind keine Paletteneinträge: `title-fill` und
+  `rule-fill`. Ob sie mitfolgen, entscheidet das Theme. Alle fünf
+  mitgelieferten lassen sie mitfolgen -- entweder als Funktion der Palette,
+  `title-fill: p => p.strong`, oder als `none`, was den Akzent meint und mit
+  ihm wandert. Beide haben dafür den Typ gewechselt: `themes.X.title-fill`
+  *auszulesen* ergab früher eine Farbe und ergibt jetzt eine Funktion, und
+  `rule-fill` ergibt `none`, wo es den Akzent ergab. Sie zu *schreiben*,
+  `themes.X + (title-fill: red)`, ist unverändert. Ein eigenes Theme,
+  das dort eine feste Farbe hinschreibt, behält sie unter jeder Palette. Das
+  ist Absicht: eine Farbe, die jemand ausdrücklich genannt hat, wird nicht
+  hinter seinem Rücken getauscht.
+]
+
+Und `themes.night` bleibt trotzdem ein Theme. Sein Zyan `#5ec8f2`
+misst 9,77 zu 1 auf dem dunklen Grund und deshalb leuchtet es dort, aber nur
+1,59 zu 1 auf seiner eigenen Schriftfarbe -- und genau die liegt hinter dem
+Akzent, sobald eine Folie umgedreht wird. `palettes.dark` nimmt darum einen
+tieferen Ton. Das Theme behält seinen; es ist eine Gestaltungsentscheidung,
+und sie ist gemessen, nicht übersehen.
+
 == Die Farben eines Themes
 
 Sechs Rollen tragen ein Theme: `paper` der Grund der Folie, `ink` der
 Fließtext, `strong` die tragende dunkle Farbe, `accent` die Signalfarbe,
-`muted` das Nebensächliche, `surface` der Grund einer Karte. Die
+`muted` das Nebensächliche, `surface` der Grund einer Karte. Mit `border` und
+`inverted` sind es dieselben acht Einträge, die auch eine Palette trägt. Die
 mitgelieferten Themes belegen sie verschieden:
 
 #show-example(
@@ -1594,6 +1668,129 @@ Unabhängig vom Theme gibt das Paket vier Farbkonstanten heraus -- `dark`,
 `accent`, `paper` und `muted` --, die Palette des Vorgabe-Aussehens. Sie sind
 handlich, wo eine Folie einen Farbton braucht und das Theme nicht gewechselt
 wird; wer das Theme tauscht, greift besser auf dessen Einträge zu.
+
+== Eine Folie umdrehen
+
+Für die eine Folie, die nur eine große Zahl trägt, gibt es `invert`. Der Grund
+wird zur Schriftfarbe der Palette, der Satz zu ihrem Grund; `muted`, `border`
+und `surface` werden aus diesen beiden gemischt, `strong` und `accent` gehen
+unverändert mit. Das Chrom zieht mit: Kopfzeile, Fußzeile, Foliennummer und
+Fortschrittsbalken stehen in denselben Farben wie die Folie unter ihnen. Karte
+und Merkkasten ebenso.
+
+In der Überschriftenschreibweise steht `#invert` im Rumpf der Folie, so wie
+`#pause`:
+
+#show-code[```typ
+== Erreicht bis 2026
+#invert
+#statement[74 %]
+```]
+
+In der Argumentschreibweise ist es ein Argument von `slide`:
+
+#show-code[```typ
+#slide([Erreicht bis 2026], invert: true)[#statement[74 %]]
+```]
+
+#warning[
+  Nur eine gewöhnliche Folie dreht sich um. Titel- und Abschnittsfolie sind
+  ganze Bilder, die das Theme selbst malt, und drei der fünf mitgelieferten
+  bauen sie aus Farben, an die eine Umkehrung nicht heranreicht; beide nehmen
+  das Argument deshalb nicht an.
+
+  Die Marke `#invert` wird überall dort gefunden, wo der Rumpf begehbar ist:
+  auf der obersten Ebene, in einem `block` oder `align`, in einer
+  Tabellenzelle, in einem Raster, beliebig tief geschachtelt, in der
+  Folienüberschrift selbst und hinter `#set`- und `#show`-Regeln. *Nicht*
+  gefunden wird sie dort, wo der Inhalt an eine Closure abgegeben wird, in die
+  der Lauf nicht hineinkommt -- in `context`, `fit`, `anim`, `card` und
+  `alternatives` --, und die Folie bleibt dann einfach stehen, wie sie ist,
+  ohne ein Wort. Gemessen sind das genau diese fünf. Wer eine davon braucht,
+  schreibt die Folie als `slide(invert: true)`, was nie am Lauf hängt.
+]
+
+== Der Kontrastvertrag
+
+Die mitgelieferten Paletten werden gemessen, bevor sie ausgeliefert werden.
+Gerechnet wird der echte WCAG-2-Kontrast: jeder Kanal linearisiert, daraus die
+relative Leuchtdichte $0.2126 R + 0.7152 G + 0.0722 B$, und aus zwei Dichten
+das Verhältnis $(L_"hell" + 0.05) \/ (L_"dunkel" + 0.05)$. Sechs Paarungen
+werden geprüft:
+
+#table(
+  columns: (auto, auto, 1fr),
+  stroke: 0.5pt + luma(180),
+  table.header([*Paarung*], [*Mindestens*], [*Wofür*]),
+  [`ink` auf `paper`], [4,5], [Fließtext auf der Folie],
+  [`ink` auf `surface`], [4,5], [Fließtext in einer Karte],
+  [`muted` auf `paper`], [4,5], [Fußzeile, Untertitel, Kopfzeile],
+  [`accent` auf `paper`], [3,0], [Striche, Fortschritt, Marke],
+  [`accent` auf `ink`], [3,0], [dasselbe auf einer umgedrehten Folie],
+  [`border` auf `paper`], [1,2], [Haarlinien],
+)
+
+Geprüft wird jede der fünf Paletten *und* ihre umgedrehte Form, als `assert`
+in `src/palettes.typ`, das beim Laden des Pakets läuft. Eine Farbe, die dort
+verschoben wird und den Vertrag verletzt, bricht den Bau mit der Zahl, die sie
+verfehlt hat.
+
+#warning[
+  *Der Vertrag gilt nur für die mitgelieferten Paletten.* Eine eigene Palette
+  wird nicht geprüft -- weder gewarnt noch umgefärbt. `palette-report(…)` gibt
+  dieselbe Messung als Liste zurück, wer sie für die eigene Palette sehen will:
+
+  #show-code[```typ
+  #for f in palette-report((paper: white, ink: black, surface: white,
+                            muted: luma(55%), accent: blue, border: luma(86%))) [
+    #f.pair: #calc.round(f.ratio, digits: 2) (will #f.min) #f.ok \
+  ]
+  ```]
+
+  `contrast(a, b)` ist die Rechnung selbst und nimmt zwei beliebige Farben.
+]
+
+*Und die fünf Themes bestehen ihn nicht.* Der Vertrag wurde über sie laufen
+gelassen, bevor die Paletten entstanden; das Ergebnis steht hier, statt
+stillschweigend weggefärbt zu werden:
+
+#table(
+  columns: (auto, 1fr),
+  stroke: 0.5pt + luma(180),
+  table.header([*Theme*], [*Was durchfällt*]),
+  [`themes.default`], [nichts, alle sechs Paarungen halten],
+  [`themes.lesson`], [`muted` auf `paper` misst 4,25 statt 4,5],
+  [`themes.night`], [`accent` auf `ink` misst 1,59 statt 3,0],
+  [`themes.plain`], [`muted` auf `paper` misst 3,35 statt 4,5;
+    `accent` auf `ink` misst 1,27 statt 3,0],
+  [`themes.editorial`], [`muted` auf `paper` misst 3,51 statt 4,5;
+    `accent` auf `paper` misst 2,84 statt 3,0],
+)
+
+Keine dieser Farben wurde geändert. Sie stehen in gemessenen Gestaltungen --
+die von `themes.lesson` stammen von einer Musterseite aus _Fundamente der
+Mathematik_ --, und ein Wechsel hätte jedes bestehende Deck anders aussehen
+lassen. Was `muted` trägt, ist Nebensächliches: Foliennummer, Untertitel,
+Kopfzeile. Wer die Zahlen einhalten will, legt die passende Palette darüber:
+
+#show-code[```typ
+#show: presentation.with(theme: themes.editorial, palette: palettes.parchment)
+```]
+
+#warning[
+  *Aus der Füllfarbe wird nicht auf die Schriftfarbe geschlossen.* Ein
+  mattes Salbeigrün wie `#aebdb3` sieht für eine Helligkeitsregel „hell" aus,
+  aber Weiß darauf misst 1,96 zu 1 -- weit unter den 4,5, die Fließtext will.
+  Deshalb rechnet das Paket mit `contrast` und färbt nirgends automatisch um.
+
+  Die eine Ausnahme steht im Theme, nicht in der Palette, und sie ist ebenfalls
+  eine Messung: wo ein Theme `strong` als *Schrift* setzt -- die Überschrift in
+  `themes.lesson`, der Abschnittstitel in `themes.plain` --, wählt es zwischen
+  `strong` und `ink` nach dem gemessenen Kontrast gegen den Grund, weil dieselbe
+  Farbe nicht zugleich dunkler Balken und Schrift auf dunklem Grund sein kann.
+  Wo die zuerst genannte Farbe reicht, und das tut sie bei allen fünf Themes
+  in ihren eigenen Farben, bleibt genau sie stehen.
+]
 
 == Die Leinwand
 
@@ -2518,6 +2715,13 @@ Medien und Brücke, zuletzt die Maße und Farben.
 // Abschnittsbilder sind Bausteine daraus und stehen nicht für sich.
 #show-module(read("../src/themes.typ"), name: "typstage",
              only: ("theme", "themes"))
+
+== Paletten
+
+// Nur, was `lib.typ` hinausreicht. `kanal`, `leuchtdichte`, `lesbar` und die
+// Prüfung selbst sind Innenleben.
+#show-module(read("../src/palettes.typ"), name: "typstage",
+             only: ("palettes", "contrast", "palette-report"))
 
 == Medien und Einbettungen
 

--- a/docs/content.typ
+++ b/docs/content.typ
@@ -1634,6 +1634,11 @@ Haken `style`: eine Funktion, die um jeden Folienrumpf gelegt wird.
   kleinen Rahmen; dieser Rahmen kennt die `#show`-Regeln der Folie nicht.
   `style` wird auf beides gelegt -- auf den Folienrumpf und auf jedes bewegte
   Element --, und nur so sehen Hintergrund und Bewegtes gleich aus.
+
+  Für die Formen, die typstage selbst zeichnet, gibt es einen zweiten Weg:
+  Label-Regeln vor `#show: presentation`. Sie erreichen mehr als `style`, denn
+  sie erreichen auch Kopf, Fuß und Titelfolie. Siehe /Labels: jede gebaute Form
+  ansprechen/ weiter unten.
 ]
 
 #tip[
@@ -1813,6 +1818,307 @@ soll:
 
 In der Argumentform sind alle drei Schreibweisen erlaubt: `slide[Rumpf]` ohne
 Titel, `slide(none)[Rumpf]` ausdrücklich ohne, `slide([Titel])[Rumpf]` mit.
+
+== Labels: jede gebaute Form ansprechen
+
+Jede Form, die typstage auf einer Folie selbst zeichnet -- die Grundfläche, das
+Kopfband, der Folientitel, die Fußzeile, der Fortschritt, der Kasten, der
+Merksatz, die große Aussage, Titel- und Abschnittsfolie, die Ersatzfläche eines
+Videos --, trägt ein festes Typst-Label. Damit ist sie von außen ansprechbar:
+eine gewöhnliche `show`-Regel genügt, kein Theme-Schlüssel, kein Fork.
+
+#show-code[```typ
+#import "@schule/typstage:0.1.0": *
+
+#show label("ts-slide-header-band"): set rect(fill: rgb("#4c1d95"))
+#show label("ts-slide-title"): set text(fill: rgb("#fde047"), style: "italic")
+#show label("ts-card"): set block(fill: rgb("#eef2ff"))
+#show label("ts-statement"): set text(fill: rgb("#be123c"), weight: "bold")
+
+#show: presentation.with(theme: themes.default)
+```]
+
+Zwei Sorten Regeln decken alles ab, getrennt danach, was sie anfassen: die
+*Flächen* -- Grundflächen, Bänder, Haarlinien, Balken, Kästen -- nehmen
+`set rect(..)`, `set block(..)`, `set circle(..)` oder `set line(..)`, die
+*Schriften* nehmen `set text(..)` mit Größe, Schnitt, Farbe, Schriftart,
+Laufweite. Beides wirkt zur Übersetzungszeit, und deshalb steht das Ergebnis
+gleich in der HTML und im PDF -- mit einer Ausnahme: Was nur im PDF gezeichnet
+wird, weil im Browser das echte `<video>` oder `<iframe>` an seiner Stelle
+steht, sieht man auch nur dort. Das betrifft die sechs Labels unter
+/Medien und Handout/.
+
+#warning[
+  *Bei den Flächen* wirkt die Kurzform, die Langform nicht:
+
+  ```typ
+  #show label("ts-slide-progress"): set rect(fill: green)          // ja
+  #show label("ts-slide-progress"): it => { set rect(fill: green); it }   // nein
+  ```
+
+  Die Kurzform legt die Stilregel *um* das gefundene Element, die Langform
+  *hinein* -- und im Rechteck steckt kein zweites Rechteck, auf das sie noch
+  wirken könnte. Wer die beiden Schreibweisen aus anderen Paketen als
+  gleichwertig kennt, läuft hier auf.
+
+  Bei den 15 Schrift-Labels sind beide Schreibweisen gleichwertig: dort steckt
+  im gefundenen Element der Text, und den erreicht eine Regel auch von innen.
+]
+
+=== Wo die Regel stehen muss
+
+*Vor* `#show: presentation`. Diese eine Stelle erreicht alles: den
+Folienhintergrund, die Chrome-Schicht mit Kopf, Fuß und Fortschritt, die
+Titelfolie und jedes bewegte Element.
+
+Der Haken `style` erreicht *nicht* dasselbe. Er wird um den *Folienrumpf*
+gelegt, und Kopf, Fuß, Fortschritt sowie Titel- und Abschnittsfolie entstehen
+daneben, nicht darin. Gemessen, jede der 37 Regeln einzeln: aus `style`
+heraus wirken genau die 13, die im Folienrumpf stehen -- die Bausteine
+`ts-card…`, `ts-callout…`, `ts-statement` und die drei Ersatzflächen
+`ts-media-…`. Die übrigen 24 bleiben dort stumm, ohne Warnung. `style` bleibt richtig für
+Typografie, die den ganzen Rumpf betrifft; für Labels ist die Stelle vor
+`#show: presentation` die richtige.
+
+#warning[
+  Eine `show`-Regel, die *hinter* `#show: presentation` steht, erreicht ein
+  getracktes Element (`anim`, `morph`) nicht. Der Grund steht schon im
+  Abschnitt über Typografie: Im Browser wird jedes bewegte Element ein zweites
+  Mal gesetzt, in einem eigenen Rahmen, und dieser Rahmen kennt die
+  `#show`-Regeln aus dem Dokumentrumpf nicht.
+
+  ```typ
+  #show: presentation.with(theme: themes.default)
+  #show label("ts-statement"): set text(fill: green)   // zu spät
+  == Eine Folie
+  #statement[fest]
+  #anim(statement[bewegt])
+  ```
+
+  In dieser Datei ist `fest` grün und `bewegt` schwarz: vier eingefärbte
+  Flächen im Hintergrund, null in der Überlagerung. Steht dieselbe Regel eine
+  Zeile weiter oben, sind es vier und sechs, und beide sehen gleich aus. Im
+  PDF fällt der Unterschied nicht auf, weil dort nichts zweimal gesetzt wird.
+
+  Das gilt für jede `#show`-Regel, nicht nur für Label-Regeln; es ist keine
+  Eigenheit der Labels.
+]
+
+=== Was eine Label-Regel ändert und was nicht
+
+Erreichbar ist, was das Paket *nicht* als ausdrückliches Argument schreibt.
+Für die Schrift ist das alles; für die Flächen sind es `fill` und `stroke`
+überall und `radius` überall dort, wo die Form eine Rundung hat -- genau die
+gibt typstage seinen Formen über eine `set`-Regel.
+
+`width` steht überall als Argument und ist deshalb nirgends erreichbar. Bei
+`height` gibt es drei Ausnahmen, und sie sind es wert, genannt zu werden:
+`ts-card`, `ts-card-bar` und `ts-callout` bekommen ihre Höhe als `auto`, und
+`auto` ist kein Wert, der eine Regel schlagen könnte. Auch in einer Reihe
+gleicher Höhe nicht: nachgemessen an der bemalten Fläche selbst wirkt
+`height:` dort ebenso.
+
+#show-code[```typ
+#show label("ts-card"): set block(height: 150pt)   // wirkt
+#show label("ts-card"): set block(width: 30%)      // wirkt nicht
+```]
+
+Die erste Zeile bläht den Kasten auf 150 pt auf und schiebt den Merksatz
+darunter aus der Folie. Bei den Chrome-Flächen, den Grundflächen und dem
+Handout-Rahmen wirkt weder das eine noch das andere; was dort eine
+`width`-Regel scheinbar ändert, sind die Blöcke *im* Inhalt, siehe den
+nächsten Kasten.
+
+Nicht erreichbar ist auch die *Anordnung* der Folie. Wie hoch der Kopf baut,
+wie weit die Linie unter dem Titel steht, wo der Balken sitzt -- das entsteht
+in `place` und `layout`, während sich das Layout zusammensetzt, und keine
+`show`-Regel reicht dort hinein. Dafür sind die Theme-Schlüssel da
+(`head-gap`, `band-height`, `rule-size` und die übrigen); sie bleiben
+unverändert bestehen.
+
+#warning[
+  Eine Regel auf `block` oder `rect` reicht nach *innen*: Sie gilt für die
+  gelabelte Fläche und für jeden Block darin. Bei `fill`, `stroke` und
+  `radius` ist das abgefangen -- der Kasten setzt innen wieder her, was das
+  Dokument gesetzt hatte, sonst liefe seine Farbe über die runden Ecken
+  hinaus. Bei den Abständen ist es nicht abgefangen, und dann verschiebt eine
+  Label-Regel die Folie:
+
+  ```typ
+  #show label("ts-card"): set block(below: 60pt)
+  == Eine Folie
+  #card(title: [Kasten])[Rumpf]
+  #callout(title: [Merke])[Merksatz]
+  ```
+
+  Gemessen mit `pdftotext -bbox` an genau dieser Folie: Der Merksatz rückt um
+  31,2 pt nach unten, und alles unter ihm mit. Die Zahl ist `60pt` minus dem
+  Blockabstand von 1,2 em, bei 24 pt Text also 28,8 pt, *je Kante*. Wer
+  `above` und `below` zugleich setzt und einen Kasten hat, über dem noch etwas
+  steht, bekommt beide Kanten und damit das Doppelte.
+
+  Das ist keine Zusage, sondern eine Nebenwirkung von Typsts Stilregeln.
+  Labels sind für Schrift und Fläche gedacht; wer Abstände will, nimmt die
+  Argumente der Bausteine oder die Theme-Schlüssel.
+]
+
+=== Das vollständige Verzeichnis
+
+Was hier steht, gibt es; was es gibt, steht hier. Die Namen folgen einem
+Schema: `ts-`, dann der *Ort*, dann der *Teil* -- der Teil steht immer hinter
+dem Ort, nie davor. Orte sind `slide` (die gewöhnliche Folie), `title-slide`,
+`section-slide`, `card`, `callout`, `statement`, `media` und `handout`.
+
+Zwei Paare unterscheiden sich nur in der Wortstellung, und ein Fehlgriff
+bleibt stumm -- er tut einfach nichts. Deshalb hier nebeneinander:
+
+#table(
+  columns: (auto, 1fr),
+  stroke: none,
+  table.header([*Name*], [*Ort und Teil*]),
+  [`ts-slide-title`], [Ort `slide`, Teil `title`: der Titel einer
+    gewöhnlichen Folie],
+  [`ts-title-slide-title`], [Ort `title-slide`, Teil `title`: der Titel der
+    Titelfolie],
+  [`ts-slide-title-rule`], [Ort `slide`: die Linie unter dem Folientitel],
+  [`ts-title-slide-rule`], [Ort `title-slide`: die Zierlinie auf der
+    Titelfolie],
+)
+
+Die Merkhilfe: Steht `slide` *vorn*, geht es um die gewöhnliche Folie; steht
+es hinter `title` oder `section`, um jene Folienart.
+
+Ein Label, das dieses Theme gerade nicht zeichnet -- ein Kopfband bei
+`header: "run"` etwa --, gibt es auf dieser Folie nicht, und eine Regel darauf
+tut dann nichts.
+
+*Die gewöhnliche Folie*
+
+#table(
+  columns: (auto, 1fr, auto),
+  stroke: none,
+  table.header([*Label*], [*Was es ist*], [*Regel*]),
+  [`ts-slide-ground`], [Die Grundfläche der Folie], [`rect`],
+  [`ts-slide-header-band`], [Das Kopfband, nur bei `header: "band"`], [`rect`],
+  [`ts-slide-header-text`], [Die laufende Kopfzeile aus Nummer und Abschnitt,
+    nur bei `header: "run"`], [`text`],
+  [`ts-slide-header-rule`], [Die Haarlinie darunter, nur bei `header: "run"`],
+    [`rect`],
+  [`ts-slide-title`], [Der Folientitel, bei allen drei Kopfarten], [`text`],
+  [`ts-slide-title-rule`], [Die Linie unter dem Titel, nur wenn
+    `rule-size > 0pt`], [`rect`],
+  [`ts-slide-footer`], [Die Fußzeile], [`text`],
+  [`ts-slide-number`], [Die Foliennummer darin], [`text`],
+  [`ts-slide-footer-rule`], [Die Haarlinie darüber, nur wenn
+    `footer-rule > 0pt`], [`rect`],
+  [`ts-slide-progress`], [Der Fortschrittsbalken, bei `progress: "tick"` der
+    wandernde Reiter], [`rect`],
+  [`ts-slide-progress-track`], [Die Bahn, auf der er wandert, nur bei
+    `progress: "tick"`], [`rect`],
+)
+
+*Die Titelfolie*
+
+#table(
+  columns: (auto, 1fr, auto),
+  stroke: none,
+  table.header([*Label*], [*Was es ist*], [*Regel*]),
+  [`ts-title-slide-ground`], [Ihre Grundfläche], [`rect`],
+  [`ts-title-slide-band`], [Das Band am oberen Rand, nur in `themes.lesson`],
+    [`rect`],
+  [`ts-title-slide-title`], [Ihr Titel], [`text`],
+  [`ts-title-slide-subtitle`], [Ihr Untertitel], [`text`],
+  [`ts-title-slide-rule`], [Die Zierlinie; `themes.editorial` hat zwei,
+    `themes.plain` keine], [`rect`],
+  [`ts-title-slide-byline`], [Die Zeile aus Verfasser und Datum], [`text`],
+)
+
+*Die Abschnittsfolie*
+
+#table(
+  columns: (auto, 1fr, auto),
+  stroke: none,
+  table.header([*Label*], [*Was es ist*], [*Regel*]),
+  [`ts-section-slide-ground`], [Ihre Grundfläche], [`rect`],
+  [`ts-section-slide-bar`], [Der Balken am linken Rand, nur in
+    `themes.lesson`], [`rect`],
+  [`ts-section-slide-title`], [Ihr Titel], [`text`],
+  [`ts-section-slide-rule`], [Die Zierlinie; `themes.night` hat zwei,
+    `themes.lesson` keine], [`rect`],
+)
+
+Eine Abschnittsfolie hat in typstage keinen Untertitel, deshalb steht in der
+Liste auch keiner.
+
+*Die Bausteine im Folienrumpf*
+
+#table(
+  columns: (auto, 1fr, auto),
+  stroke: none,
+  table.header([*Label*], [*Was es ist*], [*Regel*]),
+  [`ts-card`], [Der Kasten: Fläche, Rand, Rundung und alles darin], [`block`],
+  [`ts-card-bar`], [Der farbige Reiter über ihm, nur bei `box: "bar"`],
+    [`block`],
+  [`ts-card-title`], [Seine Überschrift], [`text`],
+  [`ts-card-disc`], [Die Scheibe der Nummer, nur bei `number:`], [`circle`],
+  [`ts-card-number`], [Die Ziffer darin], [`text`],
+  [`ts-card-body`], [Sein Rumpf], [`text`],
+  [`ts-callout`], [Der Merksatz: Fläche, Balken, Rundung. Der Balken links
+    ist kein eigenes Label, er ist der linke `stroke` dieses hier --
+    `set block(stroke: (left: 4pt + red))` färbt ihn um], [`block`],
+  [`ts-callout-title`], [Seine Überschrift], [`text`],
+  [`ts-callout-body`], [Sein Rumpf], [`text`],
+  [`ts-statement`], [Die große Aussage. `size` wirkt als Faktor darauf, weil
+    `statement` in `em` misst], [`text`],
+)
+
+*Medien und Handout*
+
+#table(
+  columns: (auto, 1fr, auto),
+  stroke: none,
+  table.header([*Label*], [*Was es ist*], [*Regel*]),
+  [`ts-media-fallback`], [Die Ersatzfläche, die im PDF für ein bewegtes
+    Element steht. Nur eine Hülle, ohne eigene Farbe und ohne Rand: eine
+    `radius`-Regel darauf sieht man deshalb nicht, eine `fill`-Regel schon],
+    [`block`],
+  [`ts-media-fallback-empty`], [Der graue Kasten darin, wenn kein `fallback:`
+    angegeben ist. Er hat eine Fläche], [`block`],
+  [`ts-media-poster`], [Die graue Fläche eines `video` ohne `poster:`],
+    [`rect`],
+  [`ts-handout-frame`], [Der gerahmte Kasten einer Folie auf der
+    Handout-Seite], [`block`],
+  [`ts-handout-lines`], [Die Schreiblinien daneben oder darunter], [`line`],
+  [`ts-handout-note`], [Die Sprechernotiz, wo es eine gibt], [`text`],
+)
+
+#info[
+  Drei Dinge, die dazugehören.
+
+  *Ein Theme mit eigener Titelfolie zeichnet keins dieser Labels.*
+  `title-slide` und `section` im Theme sind Funktionen und malen ihr Bild
+  selbst; wer eine eigene mitbringt, verliert die sechs beziehungsweise vier
+  Labels dieser Folienart, und nichts warnt davor. Die mitgelieferten fünf
+  zeichnen, was ihr Bild braucht, und nicht mehr: Band und Balken gibt es nur
+  in `themes.lesson`, `themes.plain` hat keine Zierlinie auf der Titelfolie,
+  `themes.lesson` keine auf der Abschnittsfolie. Was welches Theme zeichnet,
+  steht in der Spalte /Was es ist/.
+
+  *Die unsichtbaren Markierungen tragen keins.* Jedes bewegte Element malt ein
+  durchsichtiges Rechteck um sich, an dem der Browser es wiederfindet, und
+  `pin` macht dasselbe für ein einzelnes Zeichen. Das ist Maschinerie und
+  keine Form; beides bleibt namenlos.
+
+  *Typst-Labels und die CSS-Klassen der Laufzeit sind zwei getrennte
+  Namensräume.* `.ts-slide` im Stylesheet ist der `<section>` einer Folie im
+  Browser, `ts-slide-title` ein Typst-Label -- sie liegen einen Bindestrich
+  auseinander und haben nichts miteinander zu tun. Typsts HTML-Ausgabe legt
+  allerdings an manche Formen ein `data-typst-label`-Attribut, an die
+  Bausteine des Rumpfes zum Beispiel, an die Schriftformen nicht. Es ist
+  Beiwerk von Typst, kein Versprechen dieses Pakets: Verlass dich für CSS
+  nicht darauf.
+]
+
 
 = API-Referenz
 

--- a/examples/handbuch/README.md
+++ b/examples/handbuch/README.md
@@ -1,0 +1,23 @@
+# Beispiele, die im Handbuch stehen
+
+Die Dateien hier sind die vollständigen Präsentationen, die die beiden
+Handbücher als „vollständig und lässt sich abtippen" zeigen. Das Handbuch
+schreibt sie nicht ab, sondern liest sie:
+
+```typ
+#show-code(raw(read("../examples/handbuch/erste-praesentation.typ").trim(),
+               block: true, lang: "typ"))
+```
+
+Damit kann der Abdruck nicht von der Datei abweichen, und
+`.github/scripts/pruefe-beispiele.py` übersetzt genau die Zeichen, die im
+Handbuch stehen.
+
+| Datei | Handbuch |
+| --- | --- |
+| `erste-praesentation.typ` | `docs/content.typ`, „Eine Datei genügt" |
+| `first-deck.typ` | `docs/content-en.typ`, „One file is enough" |
+
+Nicht in `examples/` selbst ablegen: der Seitenbau übersetzt jede `.typ` dort
+als eigene Präsentation, und die sechs Beispieldecks der Website sollen sechs
+bleiben.

--- a/examples/handbuch/erste-praesentation.typ
+++ b/examples/handbuch/erste-praesentation.typ
@@ -1,0 +1,29 @@
+#import "@schule/typstage:0.1.0": *
+
+#show: presentation.with(
+  title: [Der Satz des Pythagoras],
+  subtitle: [Eine Herleitung in vier Schritten],
+  author: [Mathematik · Klasse 9],
+  date: datetime.today(),
+  transition: "slide",
+)
+
+= Worum es geht
+
+== Die Behauptung
+
+#speaker-note[Erst die Zerlegung zeigen, dann die Formel -- nicht umgekehrt.]
+
+#stagger[
+  - Ein rechtwinkliges Dreieck hat zwei Katheten und eine Hypotenuse.
+  - Über jeder Seite steht ein Quadrat.
+  - Die beiden kleinen sind zusammen so groß wie das große.
+]
+
+#v(1em)
+
+#anim(callout[Genau das behauptet der Satz.], enter: "scale")
+
+== Und das ist die Formel
+
+#statement[$ a^2 + b^2 = c^2 $]

--- a/examples/handbuch/first-deck.typ
+++ b/examples/handbuch/first-deck.typ
@@ -1,0 +1,22 @@
+#import "@schule/typstage:0.1.0": *
+
+#show: presentation.with(
+  title: [The Pythagorean Theorem],
+  subtitle: [A derivation in four steps],
+  author: [Mathematics · Year 9],
+  date: datetime.today(),
+  transition: "slide",
+)
+
+= What this is about
+
+== The claim
+
+#speaker-note[Show the dissection first, then the formula, not the other way round.]
+
+In a right-angled triangle the two shorter sides together carry as much area
+as the longest one.
+
+#pause
+
+And that is the formula: $a^2 + b^2 = c^2$

--- a/src/elements.typ
+++ b/src/elements.typ
@@ -1,6 +1,6 @@
 // Appearing, moving and staggering.
 
-#import "internal.typ": (html-output, name-of, pin-index, pin-marker,
+#import "internal.typ": (html-output, im-deck, name-of, pin-index, pin-marker,
                         step-cursor, track)
 
 /// Reveal content on particular steps.
@@ -109,10 +109,18 @@
                                          height: available.height))
     let w = calc.max(..natural.map(s => s.width), ..bounded.map(s => s.width))
     let h = calc.max(..natural.map(s => s.height), ..bounded.map(s => s.height))
-    if not html-output.get() {
-      return block(width: w, height: h, place(align, items.last()))
-    }
     let first = if start == auto { step-cursor.get().first() + 1 } else { start }
+    if not html-output.get() {
+      // Only the last version is set on paper, but the cursor moves as if all
+      // of them stood there. Every version is one step, and
+      // `info().step.total` has to report the same count in both outputs.
+      return {
+        if im-deck() {
+          step-cursor.update(c => calc.max(c, first + items.len() - 1))
+        }
+        block(width: w, height: h, place(align, items.last()))
+      }
+    }
     let last = items.len() - 1
     block(width: w, height: h, {
       for (i, v) in items.enumerate() {

--- a/src/elements.typ
+++ b/src/elements.typ
@@ -1,7 +1,8 @@
 // Appearing, moving and staggering.
 
 #import "internal.typ": (fit-meldung, html-output, im-deck, im-fit, name-of,
-                        pin-index, pin-marker, step-cursor, track)
+                        offenes-ende, pin-index, pin-marker, selector,
+                        step-cursor, track)
 
 /// Reveal content on particular steps.
 ///
@@ -14,17 +15,68 @@
 /// `enter` applies in both directions: paging back plays the same effect in
 /// reverse, taking the entrance back. `exit` only concerns a real departure,
 /// when an element falls out of its range while moving forward.
+///
+/// `after` says what the element does once its range is behind it, and it has
+/// two values.
+///
+/// - `"hidden"`, the default and what an `anim` has always done: it goes,
+///   playing `exit`, and keeps the room it had.
+/// - `"dimmed"`: it stays and is drawn muted, so a point remains legible
+///   after the talk has moved on. Nothing moves and nothing is recoloured;
+///   the element settles to 65 percent opacity, and paging back brings it up
+///   again. That number is measured, and the manual says against what.
+///
+/// On paper `after` does nothing at all. A page shows every step at once, and
+/// a point that is only quiet because the talk has moved past it has no
+/// "past" on a handout. This is the same rule that already holds for
+/// `"hidden"`: what leaves its range in the browser is still printed.
+///
+/// `after` needs a range that ends. `at: auto` and `at: 3` run to the end of
+/// the slide, and an element that never leaves has no after; the package says
+/// so instead of doing nothing. `at: "3"` is that one step, `at: "2-3"` a
+/// range.
+/// What `anim` does once its arguments have been checked.
+///
+/// Split out for `stagger`, and for one reason: `dim-freiwillig`. An element
+/// written by hand with `after: "dimmed"` whose range ends with the slide is a
+/// mistake -- it would rest dim on a step that never comes -- and the check at
+/// the end of the document says so. A `stagger(dim: true)` produces exactly
+/// that shape for its *last* point on purpose: the point being talked about
+/// stays bright, and dims only if the deck goes on. So its points say they may
+/// end with the slide, and the late check leaves them alone. The flag rides in
+/// the sprite record rather than in `extra`, which becomes markup attributes.
+#let anim-kern(body, at: auto, enter: "fade-up", exit: "fade",
+               after: "hidden", duration: auto, delay: 0,
+               dim-freiwillig: false) = track(
+  "anim", body, at: at, dim-freiwillig: dim-freiwillig, extra: (
+    enter: enter, exit: exit, delay: delay,
+    duration: if duration == auto { none } else { duration },
+    // Only the departure from the default travels into the markup. `hidden`
+    // is what every sprite has always done after its range, and writing it
+    // out would put a new attribute on every element of every deck.
+    after: if after == "dimmed" { after } else { none },
+  ))
+
 #let anim(
   body,
   at: auto,
   enter: "fade-up",
   exit: "fade",
+  after: "hidden",
   duration: auto,
   delay: 0,
-) = track("anim", body, at: at, extra: (
-  enter: enter, exit: exit, delay: delay,
-  duration: if duration == auto { none } else { duration },
-))
+) = {
+  assert(after in ("hidden", "dimmed"), message:
+    "typstage: anim(after: ...) is \"hidden\" or \"dimmed\", not \""
+    + str(after) + "\".")
+  assert(after == "hidden" or (at != auto and not offenes-ende(selector(at))),
+         message: "typstage: anim(after: \"dimmed\") wants a range that ends. "
+    + "`at: auto` and `at: 3` run to the end of the slide, so there is no "
+    + "after for the element to rest in. Write `at: \"3\"` for that one step "
+    + "or `at: \"2-3\"` for a range.")
+  anim-kern(body, at: at, enter: enter, exit: exit, after: after,
+            duration: duration, delay: delay)
+}
 
 /// Magic move: the same `name` on two slides, and the thing flies across.
 ///
@@ -198,6 +250,17 @@
 /// `start` is `auto`: the sequence continues where the slide left off.
 /// `stride: 0` makes everything appear on the same step and staggers only
 /// through `stagger`, in milliseconds.
+///
+/// `dim: true` turns the sequence into a walk: the point being discussed
+/// stands there, the ones before it stay legible but muted. Every point then
+/// holds exactly its own step instead of the rest of the slide, and rests at
+/// `anim`'s `after: "dimmed"` from the next step on. Paging back brings each
+/// one up again.
+///
+/// Two things follow from that and are worth knowing before reaching for it.
+/// The last point dims too as soon as the slide has a further step after it,
+/// because then the walk has moved on from it as well. And `stride: 0`, which
+/// puts every point on one step, makes them all dim together on the next.
 #let stagger(
   ..items,
   start: auto,
@@ -206,6 +269,7 @@
   duration: auto,
   stagger: 60,
   spacing: 0.65em,
+  dim: false,
 ) = context {
   // Asked here rather than left to the `anim`s below, so the message names the
   // function the deck actually wrote. An assertion, not a placed `fit-verbot`,
@@ -223,11 +287,19 @@
     parts.filter(c => c.func() in (list.item, enum.item))
   } else { () }
 
+  // Where a point rests. Without `dim` it stays for the rest of the slide, so
+  // its range stays open; with `dim` it holds its own step and dims after it.
+  // Both selectors carry the same highest number, so the slide keeps its step
+  // count either way.
+  let bereich(n) = if dim { str(n) } else { str(n) + "-" }
+  let ruhe = if dim { "dimmed" } else { "hidden" }
+
   if punkte.len() == 0 {
     // No list: the pieces in order, each as its own block.
     for (i, b) in gegeben.enumerate() {
-      block(anim(b, at: str(start + i * stride) + "-",
-                 enter: enter, duration: duration, delay: i * stagger))
+      block(anim-kern(b, at: bereich(start + i * stride), after: ruhe,
+                      dim-freiwillig: dim, enter: enter, duration: duration,
+                      delay: i * stagger))
     }
     return
   }
@@ -241,7 +313,7 @@
 
   for (i, p) in punkte.enumerate() {
     if i > 0 { v(spacing, weak: true) }
-    anim(
+    anim-kern(
       grid(
         columns: (column, 1fr),
         column-gutter: 0.5em,
@@ -252,7 +324,7 @@
         align: (right + top, left + top),
         marks.at(i), p.body,
       ),
-      at: str(start + i * stride) + "-",
+      at: bereich(start + i * stride), after: ruhe, dim-freiwillig: dim,
       enter: enter, duration: duration, delay: i * stagger,
     )
   }

--- a/src/elements.typ
+++ b/src/elements.typ
@@ -1,7 +1,7 @@
 // Appearing, moving and staggering.
 
-#import "internal.typ": (html-output, im-deck, name-of, pin-index, pin-marker,
-                        step-cursor, track)
+#import "internal.typ": (fit-meldung, html-output, im-deck, im-fit, name-of,
+                        pin-index, pin-marker, step-cursor, track)
 
 /// Reveal content on particular steps.
 ///
@@ -101,6 +101,12 @@
   // whole thing, not inside it.
   let shell-outer = if inline { box } else { it => it }
   shell-outer(layout(available => context {
+    // On paper `alternatives` never reaches `track`, it only moves the cursor,
+    // so the fit check cannot be left to `track` here. Asked as an assertion
+    // rather than by placing `fit-verbot`, because the paged branch below
+    // leaves through a `return` and a `return` drops whatever was joined
+    // before it.
+    assert(im-fit.get() == 0, message: fit-meldung("alternatives"))
     // Measure twice, the larger one wins: the same trap as in `track`.
     // `height: 100%` in one version would otherwise collapse to zero, and
     // measuring only against the available height would clip any overflow.
@@ -201,6 +207,10 @@
   stagger: 60,
   spacing: 0.65em,
 ) = context {
+  // Asked here rather than left to the `anim`s below, so the message names the
+  // function the deck actually wrote. An assertion, not a placed `fit-verbot`,
+  // because the list branch below leaves through a `return`.
+  assert(im-fit.get() == 0, message: fit-meldung("stagger"))
   let start = if start == auto { step-cursor.get().first() + 1 } else { start }
   let gegeben = items.pos()
   assert(gegeben.len() > 0, message: "typstage: stagger() wants something to stagger")

--- a/src/internal.typ
+++ b/src/internal.typ
@@ -73,6 +73,24 @@
   } else { "" }
 }
 
+/// A speaker note has to carry text, because nothing else reaches the speaker.
+///
+/// The presenter view transports the note as an HTML attribute, so it can only
+/// ever be a string, and the handout prints the note only where there is text
+/// in it. A note built purely out of layout therefore arrives nowhere -- and
+/// used to do so without a word. Measured: `speaker-note[#fit(table)]` left
+/// the handout with an empty ruled column and the presenter view saying "no
+/// note". The same held for a bare `rect` or a `layout()` long before `fit`
+/// existed; `fit` is only the first documented function that leads there.
+#let notiz-pruefen(body) = {
+  assert(plain-text(body).trim() != "", message:
+    "typstage: a speaker note has to contain text. The presenter view carries "
+    + "the note as plain text, and the handout prints it only where there is "
+    + "text, so a note made purely of layout -- fit(), a bare rect, an image "
+    + "-- would reach neither. Write the note as text. What is meant to be "
+    + "seen belongs on the slide, not in the note.")
+}
+
 /// Largest step number occurring in a selector.
 #let max-step(at) = {
   let numbers = at.matches(regex("\d+")).map(m => int(m.text))
@@ -401,6 +419,119 @@
   false
 }
 
+// ── Fitting content into the room it has ─────────────────────────────────────
+//
+// The geometry below is adapted from mosaic's `fit`, which adapted Touying
+// 0.7.4's `fit-to-width` and `fit-to-height`; Touying credits the fitting work
+// to Andreas Kröpelin (Polylux PR #91) and to ntjess. All three are under the
+// MIT license, as is this package.
+
+/// How many `fit` blocks the content being laid out sits inside.
+///
+/// A count, not a yes or no, so a fit inside a fit puts the outer one back
+/// when it is done. Updated as a function of the previous value and never read
+/// and written back, for the reason spelled out at `step-here`.
+#let im-fit = state("typstage-in-fit", 0)
+
+/// A length no fitter can work with.
+///
+/// Under `measure` a region is reported as unbounded, and a fit inside a
+/// container that has no height of its own gets nothing. Both would drive the
+/// factor to infinity or to zero, so both mean "leave the body alone".
+#let unloesbar(l) = (
+  float.is-infinite(l.pt()) or float.is-nan(l.pt()) or l <= 0pt
+)
+
+/// A `width` or `height` argument against the region that hosts it.
+///
+/// `auto` is the whole region. A ratio counts against it, a length is itself,
+/// and a length is measured rather than read, because `2em` only becomes
+/// points where the text size is known. Must be called inside a context.
+#let fit-mass(wert, ganz) = {
+  if wert == auto { ganz }
+  else if type(wert) == ratio { ganz * wert }
+  else if type(wert) == relative { ganz * wert.ratio + measure(v(wert.length)).height }
+  else if type(wert) == length { measure(v(wert)).height }
+  else {
+    panic("typstage: fit() takes auto, a length or a ratio for width and "
+          + "height, not " + str(type(wert)))
+  }
+}
+
+/// Content that exactly fills its place measures as 100%, so that is the line
+/// between growing and shrinking rather than a number to turn.
+///
+/// The tolerance around it is a guard against rounding, not a setting. A block
+/// that fits to within a fraction of a point reports a factor a hair off 100%,
+/// and rescaling on that would resize something that was already right.
+#let fit-toleranz = 0.05%
+
+/// The one factor that brings a measured size into the room it has.
+///
+/// The smaller of the two axes wins, so the proportions are kept. An axis
+/// whose measure is zero constrains nothing.
+#let fit-faktor(mass, breite, hoehe) = {
+  let werte = ()
+  if mass.width > 0pt { werte.push(breite / mass.width) }
+  if mass.height > 0pt { werte.push(hoehe / mass.height) }
+  if werte.len() == 0 { 100% } else { calc.min(..werte) * 100% }
+}
+
+/// Does a body carry a `pause`, however deep?
+///
+/// `apply-pauses` walks only the top level of a slide body, and it walks it
+/// *before* anything is laid out. A `fit` holds its body inside a closure, so
+/// that walk never reaches in. This one goes all the way down, because inside
+/// a fit a pause is lost wherever it stands, not only at the top.
+#let hat-pause(c) = {
+  if type(c) != content { return false }
+  if c.func() == metadata { return c.value == "typstage-pause" }
+  if c.has("children") { return c.children.any(hat-pause) }
+  if c.has("child") { return hat-pause(c.child) }
+  if c.has("body") { return hat-pause(c.body) }
+  false
+}
+
+/// What a fit says when something inside it may not be there.
+///
+/// Named, because the same sentence has to come out of nine functions and out
+/// of the pause check, and a reader who meets it twice should not have to
+/// wonder whether the two are the same rule.
+///
+/// Both halves of it were measured. A pause inside a fit is never found: the
+/// presentation looks for it by walking the slide body, and a fitted block is
+/// a closure it cannot walk into. On a slide carrying two pauses that took the
+/// step count from three down to one, and nothing said so. And a measured
+/// block has no height to reckon against: the width is the one a wrapping fit
+/// hands in, but the height comes back unbounded, and that is the axis on
+/// which a tracked element resolves `height: 100%` and `1fr` and reserves the
+/// room for its marker. Measured: an `anim` inside a fit was not scaled at
+/// all and ran off the bottom of the slide.
+///
+/// It is deliberately not said that every announced thing would vanish.
+/// `speaker-note` and `bridge-job` were measured *inside* a fit and both come
+/// through -- a `measure` commits no state, so they are recorded exactly once.
+/// They are therefore allowed. Only what settles geometry is refused.
+#let fit-meldung(was) = (
+  "typstage: " + was + " cannot stand inside fit(). A fitted block has to be "
+  + "measured, and two things do not survive that. A pause is found by "
+  + "walking the slide body, which cannot reach into a measured block, so its "
+  + "steps fall away without a word: measured, three steps became one. And a "
+  + "measured block has no height to reckon against, so a reveal there "
+  + "settles its own height and the room its marker reserves against nothing: "
+  + "measured, an anim inside a fit was not scaled at all and ran off the "
+  + "slide. Put the " + was + " outside the fit(), or fit what stands inside "
+  + "the reveal instead of fitting around it."
+)
+
+/// Refuse a thing that only works because the presentation can walk the slide.
+///
+/// Placed, not assigned: it is a context and has to reach the document to be
+/// evaluated at all.
+#let fit-verbot(was) = context {
+  assert(im-fit.get() == 0, message: fit-meldung(was))
+}
+
 #let track(kind, body, at: "1-", extra: (:), raw-frames: none, inline: false,
            width: auto) = {
   // The `box` has to sit around the *whole* construction, not inside it:
@@ -408,6 +539,9 @@
   // further in would still break the line it sits in.
   let shell-outer = if inline { box } else { it => it }
   shell-outer(context {
+  // Nothing tracked may sit inside a fit, and this is where all five kinds
+  // come through, so it is asked once here rather than five times outside.
+  assert(im-fit.get() == 0, message: fit-meldung(kind))
   // A pure `fr` spacer is passed through instead of tracked. Measured it
   // would come out as the full remaining height and push the siblings out
   // of the slide (verified: 86% instead of 76%). Passed through, the parent

--- a/src/internal.typ
+++ b/src/internal.typ
@@ -101,6 +101,82 @@
 /// its name with one on the slide before it, or the flight there is lost.
 #let morph-index = state("typstage-morphs", ())
 
+/// A stroke that no longer folds into the one it is set inside.
+///
+/// A `stroke` keeps `auto` for whatever it does not name, and `auto` is
+/// filled in from the enclosing stroke rather than from the default. That
+/// matters here because the box hands its own border to a `set` rule and
+/// puts the document's back inside: a deck's `#set block(stroke: red)` names
+/// only the paint, so inside the box's `0.7pt + border` it came out 0.7pt red
+/// instead of 1pt red. Measured on the card's colored tab, in all five
+/// themes.
+///
+/// Every field has to be pinned, not just the thickness. Pinning only that
+/// one left the same fold a row further along: `#set block(stroke: 3pt)`
+/// names the thickness and leaves the paint on `auto`, and the inner edges
+/// then came out in the box's border grey instead of black. Measured on a
+/// deck without a single label, seven spellings affected, among them
+/// `stroke: 3pt` and `stroke: (dash: "dashed")`.
+#let fester-strich(v) = {
+  let einer(x) = if type(x) == stroke {
+    stroke(
+      paint: if x.paint == auto { black } else { x.paint },
+      thickness: if x.thickness == auto { 1pt } else { x.thickness },
+      cap: if x.cap == auto { "butt" } else { x.cap },
+      join: if x.join == auto { "miter" } else { x.join },
+      dash: if x.dash == auto { none } else { x.dash },
+      miter-limit: if x.miter-limit == auto { 4.0 } else { x.miter-limit },
+    )
+  } else { x }
+  if type(v) == dictionary {
+    v.pairs().map(((k, x)) => (k, einer(x))).to-dict()
+  } else { einer(v) }
+}
+
+/// The block style the surrounding document has set.
+///
+/// `card`, `callout` and the handout frame hand their own surface to a `set`
+/// rule instead of writing it as an argument, because only then can a
+/// `show label(..): set block(fill: ..)` in a deck reach it. That rule would
+/// otherwise run on into every block of their contents and out over the
+/// rounded corners, so it is put back inside, and this is what gets put back.
+///
+/// Not simply `none` and `0pt`. Everything Typst reports here is *partial*,
+/// and a partial value folds into the one it is set inside instead of
+/// replacing it. Three shapes of that, all measured on a deck that carries no
+/// label at all.
+///
+/// An unset `stroke` or `radius` comes back as an *empty dictionary*, and
+/// setting that again changes nothing: that is how the callout's left bar
+/// first ended up beside every line of its own text. It becomes `none` and
+/// `0pt` by hand.
+///
+/// A dictionary names only the sides it was given, so `stroke: (left: green)`
+/// would leave the box's own border on the other three. The missing sides and
+/// corners are filled in.
+///
+/// And a stroke keeps `auto` for what it does not name: `stroke: red` inside
+/// the card's `0.7pt + border` drew 0.7pt red instead of 1pt red. That is what
+/// `fester-strich` is for.
+///
+/// Must be called inside a context.
+#let umgebungs-block() = {
+  let leer(v) = type(v) == dictionary and v.len() == 0
+  let voll(v, seiten, fehlt) = if type(v) != dictionary { v } else {
+    seiten.map(k => (k, v.at(k, default: fehlt))).to-dict()
+  }
+  (
+    fill: block.fill,
+    stroke: if leer(block.stroke) { none } else {
+      fester-strich(voll(block.stroke, ("top", "right", "bottom", "left"), none))
+    },
+    radius: if leer(block.radius) { 0pt } else {
+      voll(block.radius,
+           ("top-left", "top-right", "bottom-left", "bottom-right"), 0pt)
+    },
+  )
+}
+
 /// The height of the row a box is currently standing in, or `none`.
 ///
 /// `side-by-side(equal: true)` measures its columns, fixes the largest

--- a/src/internal.typ
+++ b/src/internal.typ
@@ -532,6 +532,174 @@
   assert(im-fit.get() == 0, message: fit-meldung(was))
 }
 
+// ── The check that a slide fits into its body ───────────────────────────
+//
+// mosaic measures every cell on every frame; here the unit is the slide body,
+// the one block `slide-body` places the deck's content into. Header band,
+// title line, footer and progress are drawn beside it with `place` and are not
+// part of it, so the check asks exactly the question a deck can act on: does
+// what I wrote fit into the room I was given?
+//
+// Why it is worth more here than in a package that only makes pages: a slide
+// of ours goes into an SVG frame of fixed size and is scaled in the browser.
+// What sticks out is cut away or drawn into the neighbourhood, depending on
+// the frame, and either way it is first seen at the projector. A page one
+// leafs through shows it.
+
+/// How far a body may stick out before it is reported.
+///
+/// Not a setting but a guard against rounding: a body that fills its room to
+/// the last point comes back a fraction over it, and that must not turn into a
+/// message. Measured across the 63 slides of the six example decks, the fullest
+/// body stops 20.83pt short of its room and the next one 35.13pt, so nothing
+/// real comes anywhere near this line.
+#let ueberlauf-toleranz = 0.5pt
+
+/// One record, and the only thing this check leaves behind.
+///
+/// Typst gives a package no warning channel, so a finding is filed as
+/// queryable metadata and nothing is printed on its own. `overflow: "error"`
+/// reads the records back at the end of the document and stops with all of
+/// them at once; a tool reads them with
+///
+/// ```sh
+/// typst eval --target html --features html --in deck.typ \
+///   'query(<typstage-overflow>).map(e => e.value)'
+/// ```
+///
+/// The numbers travel as plain numbers in points, not as lengths, so that the
+/// query can write them as JSON.
+#let ueberlauf-satz(nr, schritt, hoch, raum) = [#metadata((
+  slide: nr,
+  step: schritt,
+  height: calc.round(hoch.pt(), digits: 2),
+  room: calc.round(raum.pt(), digits: 2),
+  over: calc.round((hoch - raum).pt(), digits: 2),
+)) <typstage-overflow>]
+
+/// The step from which an overflow is provably on the screen.
+///
+/// The layout of a slide does not move as the deck is paged through: every
+/// tracked element holds its full room with `hide()` from the first step on,
+/// and `alternatives` sets its versions on top of each other in a box as large
+/// as the largest. So the body is exactly as tall on step one as on step five,
+/// and "does it fit" is a question about the slide. What changes with the step
+/// is only what is *drawn*: an `anim` that hangs over the bottom edge is
+/// invisible until its step, and only then is there something to see.
+///
+/// So the step is read off the room the overflow needs, not off a second
+/// layout. Everything that only comes in after step k is invisible there and
+/// together it is `later` tall. If the body sticks out further than that, then
+/// even with all of it taken away something would still be hanging over the
+/// edge, and that something is visible on step k. The smallest k for which
+/// that holds is the answer, and step one is the answer whenever the slide
+/// carries no reveal at all.
+///
+/// It is a lower bound, not an exact answer, and the message says so with "at
+/// the earliest". `later` adds up the heights of the reveals and nothing else,
+/// so every gap between them -- block spacing, a `v()`, the space between
+/// paragraphs -- counts in the body's height and in no reveal. Measured: a
+/// 350pt box, a `v(100pt)` and an `anim(at: 4)` below it are reported from
+/// step 1, while the overrun is only on the screen from step 4. Two effects
+/// push the other way and do not cancel it: a nested reveal is counted twice,
+/// once in its own right and once inside the element around it. Where the
+/// thing that overruns is itself a reveal and nothing empty stands above it,
+/// the step is exact -- measured, `anim(at: 3)` is reported from step 3.
+/// The slide is named correctly either way, and that is the part to act on.
+///
+/// It cannot be done by measuring the same body once per step, and that was
+/// tried first. Introspection inside a `measure` of content that also stands
+/// in the document is resolved at the *document's* copy, not where the
+/// measurement is written: with a state set to 4 in front of it, a measurement
+/// of such a block read 0 and returned the layout of the real one, in HTML and
+/// on paper alike. So a check cannot tell the elements of a body that they are
+/// being measured for step 3.
+#let ueberlauf-schritt(liste, ueber) = {
+  let spaeter(k) = liste.filter(sp => sp.step > k)
+    .fold(0pt, (summe, sp) => summe + sp.height)
+  let stufen = ((1,) + liste.map(sp => sp.step)).dedup().sorted()
+  let treffer = stufen.find(k => ueber > spaeter(k))
+  // `spaeter` is 0 at the last step, so there is always one. Named all the
+  // same, because a `find` that comes back empty must not become a panic in a
+  // check that is meant to help.
+  if treffer == none { calc.max(1, ..stufen) } else { treffer }
+}
+
+/// Measure one slide body against the room it was given.
+///
+/// Two measurements, and both are needed. The one that decides *whether* there
+/// is an overflow is taken inside the real room, because content that lays
+/// itself out against the room it gets only settles when it has one: two
+/// balanced `columns` measure 338.16pt inside their room and 366.94pt without
+/// it, and reporting the second would be inventing an overflow that is not on
+/// the slide. The one that says *by how much* is taken without a height,
+/// because a measurement with one is capped at it: the same body that
+/// saturates the room at 364.61pt is 395.71pt when asked freely, and the
+/// difference is exactly what the capped number hides.
+///
+/// So a body is reported only where the capped measurement fills the room to
+/// the last point, and the free one is then read for the amount.
+///
+/// Only the height. `measure` caps the width it reports at the width it is
+/// given as well, and there is no way around that one: a table of 516.14pt
+/// measured inside 200pt reports 200pt, so a body that is too wide cannot be
+/// told from one that fills its column. `fit` is the answer to that case.
+///
+/// What still reads low, and is therefore missed: a `height: 100%` inside the
+/// body measures 0, a `1fr` collapses, and anything that draws outside its own
+/// layout box -- `scale`, `move`, `place` with an offset -- is invisible to a
+/// measurement altogether. What still reads high, and is therefore over-
+/// reported: trailing spacing, a `v()` at the end of a body, which takes room
+/// in the measurement but draws nothing.
+#let ueberlauf-pruefen(nr, rumpf, breite, raum, schritte: true) = context {
+  // Does it fit at all? Anything that comes back short of the room has
+  // settled inside it and is done with.
+  if measure(rumpf, width: breite, height: raum).height < raum - ueberlauf-toleranz {
+    return
+  }
+  let hoch = measure(rumpf, width: breite).height
+  if hoch - raum <= ueberlauf-toleranz { return }
+  // On paper every step stands on the page at once, so there is no step to
+  // name and 0 says so.
+  let schritt = if schritte { ueberlauf-schritt(sprites.get(), hoch - raum) } else { 0 }
+  ueberlauf-satz(nr, schritt, hoch, raum)
+}
+
+/// Read the records back and stop with all of them at once.
+///
+/// At the end of the deck, not at the first finding: whoever runs the check
+/// before a talk wants the list, not one place at a time with a compile run
+/// between them.
+///
+/// Deduplicated, because a `bundle()` writes several outputs from one source
+/// and a slide would otherwise be named once per output.
+#let ueberlauf-bericht(modus) = if modus != "error" { [] } else { context {
+  let roh = query(<typstage-overflow>).map(e => e.value)
+  // One line per slide, not one per record. A `bundle()` writes several
+  // outputs from one source, so the same slide is measured once per output
+  // and `dedup` does not join those records: they differ in `step`, because
+  // paged output has none. Without this a bundle reported one overrunning
+  // slide as "2 slides run over", and with a step-dependent height as three.
+  // The richest record of each slide is kept, so a step survives where one
+  // was found.
+  let funde = roh.map(f => f.slide).dedup().sorted().map(nr =>
+    roh.filter(f => f.slide == nr).sorted(key: f => f.step).last())
+  let zeile(f) = ("  slide " + str(f.slide)
+    + (if f.step > 0 { ", from step " + str(f.step) + " at the earliest" } else { "" })
+    + ": " + str(f.over) + "pt too tall, "
+    + str(f.height) + "pt of content in " + str(f.room) + "pt of room")
+  assert(funde.len() == 0, message:
+    "typstage: " + str(funde.len())
+    + (if funde.len() == 1 { " slide runs" } else { " slides run" })
+    + " over the room the body has. A slide is a frame of fixed size: in the "
+    + "browser what sticks out is cut away or drawn beside the slide, on "
+    + "paper it stands over the edge. Neither is seen while writing.\n"
+    + funde.map(zeile).join("\n")
+    + "\nShorten the slide, split it, or put the block that does not fit into "
+    + "fit(). overflow: \"record\" files the same records for querying and "
+    + "carries on instead of stopping.")
+} }
+
 #let track(kind, body, at: "1-", extra: (:), raw-frames: none, inline: false,
            width: auto) = {
   // The `box` has to sit around the *whole* construction, not inside it:

--- a/src/internal.typ
+++ b/src/internal.typ
@@ -492,6 +492,25 @@
   false
 }
 
+/// Does the top level of a slide body carry the `invert` marker?
+///
+/// Deliberately the *shallow* walk, the same one `apply-pauses` does, and not
+/// the one above. It runs on every slide of every deck, before anything is
+/// laid out, and a full descent into every block of every slide would be paid
+/// for by decks that never invert a slide. A `#set` or `#show` written above
+/// the marker wraps it in a `styled`, and a marker produced by a `#for` sits
+/// in a nested `sequence`; both are unpacked, so the two cases that actually
+/// happen are covered. Deeper than that, the marker is not found, and the
+/// slide is simply not inverted.
+#let hat-invert(body) = {
+  if type(body) != content { return false }
+  if body.func() == metadata { return body.value == "typstage-invert" }
+  if body.has("children") { return body.children.any(hat-invert) }
+  if body.has("child") { return hat-invert(body.child) }
+  if body.has("body") { return hat-invert(body.body) }
+  false
+}
+
 /// What a fit says when something inside it may not be there.
 ///
 /// Named, because the same sentence has to come out of nine functions and out

--- a/src/internal.typ
+++ b/src/internal.typ
@@ -117,6 +117,16 @@
   if werte.len() == 0 { 1 } else { calc.max(1, calc.min(..werte)) }
 }
 
+/// Does a selector run to the end of the slide?
+///
+/// `"2-"` does, and so does everything an `int` or `auto` turns into. `"3"`,
+/// `"2-3"` and `"2,4"` do not: they have a last step, and therefore an after.
+///
+/// Only what has an after can rest in a state after it. `anim(after:
+/// "dimmed")` on an open selector would be a promise nothing ever redeems, so
+/// it is refused rather than quietly ignored.
+#let offenes-ende(sel) = sel.split(",").any(t => t.trim().ends-with("-"))
+
 /// Does a selector cover the first step?
 ///
 /// Decides whether a morph is already present when the slide is entered.
@@ -138,6 +148,19 @@
 /// stands from step one. Checked at the end: a delayed morph must not share
 /// its name with one on the slide before it, or the flight there is lost.
 #let morph-index = state("typstage-morphs", ())
+
+/// Every element that asked to rest dimmed: its slide and the last step of
+/// its range. Checked at the end for the same reason the morphs are.
+///
+/// `anim(after: "dimmed")` refuses an open range on the spot, because a
+/// selector that runs to the end of the slide plainly has no after. But a
+/// *closed* range can still end with the slide -- `at: "1-2"` on a slide that
+/// only ever reaches step 2 -- and then the element never dims either, and
+/// nothing says so. That cannot be seen where the element is written: the
+/// number of steps a slide has is only settled once the slide has been laid
+/// out. So it is noted here and asked at the end, the same late question the
+/// morph names are put to.
+#let dim-index = state("typstage-dims", ())
 
 /// A stroke that no longer folds into the one it is set inside.
 ///
@@ -720,7 +743,7 @@
 } }
 
 #let track(kind, body, at: "1-", extra: (:), raw-frames: none, inline: false,
-           width: auto) = {
+           width: auto, dim-freiwillig: false) = {
   // The `box` has to sit around the *whole* construction, not inside it:
   // `layout()` is block-level, so an inline element that only chooses a `box`
   // further in would still break the line it sits in.
@@ -879,10 +902,14 @@
         width: if fuellt { w } else { room },
         height: if available.height == float("inf") { auto } else { available.height },
       )
+      // `dim-freiwillig` rides in the sprite record and not in `extra`, which
+      // becomes `data-` attributes one for one. It is only read by the check
+      // at the end of the document and has no business in the markup.
       sprites.update(a => a + ((kind: kind, at: selected, extra: extra, body: body,
                                 raw-frames: raw-frames, width: w,
                                 height: m.height, region: region, pad: luft,
-                                step: erster, style: style),))
+                                step: erster, style: style,
+                                dim-freiwillig: dim-freiwillig),))
       // A `box` is inline and puts its baseline on the bottom edge, and with a
       // two-line list item the bullet would drop a line. Block content gets a
       // `block`.

--- a/src/internal.typ
+++ b/src/internal.typ
@@ -79,6 +79,26 @@
   if numbers.len() == 0 { 1 } else { calc.max(..numbers) }
 }
 
+/// Smallest step number a selector covers.
+///
+/// This is the step an element *first* stands on, and that is what
+/// `info().step.number` reports inside it. Not `max-step`, which answers a
+/// different question: how far the cursor has to be pushed so that whatever
+/// follows carries on after this element. For `"1-2"` the two differ, 1
+/// against 2, and only the 1 is the step on which the thing appears.
+///
+/// An open lower end (`"-3"`) and a selector without a number both mean the
+/// first step.
+#let min-step(at) = {
+  let werte = at.split(",").map(t => t.trim()).filter(t => t != "").map(t => {
+    if t.starts-with("-") { 1 } else {
+      let z = t.matches(regex("\d+"))
+      if z.len() == 0 { 1 } else { int(z.first().text) }
+    }
+  })
+  if werte.len() == 0 { 1 } else { calc.max(1, calc.min(..werte)) }
+}
+
 /// Does a selector cover the first step?
 ///
 /// Decides whether a morph is already present when the slide is entered.
@@ -201,6 +221,93 @@
 /// has to be able to tell them apart.
 #let slide-counter = counter("typstage-slide")
 
+/// What the deck knows about itself, written once per slide.
+///
+/// The value is `(nr: int, data: dictionary)`. `data` is exactly what `info()`
+/// hands out, minus the step reading; the presentation writes it here before
+/// the slide is laid out, and *everything* that prints one of those numbers
+/// reads it from here: the footer, the fraction, the progress bar, the running
+/// header, and a deck's own `info()`. That is the point of the detour. As long
+/// as there is one dictionary per slide, a hand-built footer and the built-in
+/// one cannot print different numbers, because there is nothing else to count.
+///
+/// `nr` counts every slide, title and section slides included, and is kept out
+/// of `data` on purpose: `slide.number` deliberately does *not* count those,
+/// and two numbers next to each other that differ by a title slide would be a
+/// trap. It is needed here only as the key under which a slide files its step
+/// count.
+#let deck-info = state("typstage-info", none)
+
+/// Is a presentation being laid out right now?
+///
+/// Steps mean something only inside one, and only there does the cursor get
+/// set back to nothing at the start of every slide. Outside, counting would
+/// not merely be pointless, it would not settle: `stagger` reads the cursor
+/// and hands `track` a selector built from what it read, so read and write
+/// chase each other with nothing to anchor them. Measured on the manual, which
+/// sets `stagger`, `alternatives` and `tiles` examples on their own on a page:
+/// 0, 10, 15, 18, 21 over five runs, and Typst gives up with "did not
+/// converge".
+///
+/// In HTML output `html-output` already draws the same line; this draws it for
+/// paged output, where the counting is new.
+///
+/// Must be called inside a context.
+#let im-deck() = deck-info.get() != none
+
+/// The steps the content being laid out right now stands inside, innermost
+/// last. Empty outside any tracked element.
+///
+/// A stack, and pushed and popped with `update(fn)` rather than saved with a
+/// `get()` and put back. That is the whole reason it is a stack, and it was
+/// paid for: with a `get()`, the value *written* depended on a value *read*,
+/// and Typst settles such a chain at one link per layout run. On a slide with
+/// four tracked elements the chain ran past the five runs Typst allows, and it
+/// said so: "did not converge", with the reading coming out 1, 1, 1, 1, 3 and
+/// only the run after that saying 4. An update that is a function of the
+/// previous value needs no read, so the whole stack settles in one run.
+///
+/// It says nothing about a sprite: there `sprite-number` answers, because the
+/// step of a sprite would take a layout run too long to travel through a state
+/// of its own.
+#let step-here = state("typstage-step-here", ())
+
+/// The step the content being laid out right now first stands on.
+///
+/// 1 outside any tracked element, and inside one the first step of its
+/// selector. Must be called inside a context.
+/// Which sprite is being laid out, by its element number, or `none`.
+///
+/// Set outright by `sprite-markup`, and the *number* is the point: it is the
+/// running index of the element, which settles as soon as the background frame
+/// has run. Its step does not, because the step comes off the cursor, and a
+/// cursor-reading group such as `tiles` or `stagger` between two reveals makes
+/// that a chain several layout runs long. Handing the step itself through a
+/// state put one more run on top of that chain, and Typst allows five:
+/// measured on `anim`, `tiles`, `anim` with an `info()` inside, the reading
+/// came out 1, 1, 1, 1, 3 and settled on 4 only afterwards, with "did not
+/// converge" to go with it. Reading the step out of `sprites` here instead of
+/// carrying it in costs nothing and lands in one run.
+#let sprite-number = state("typstage-sprite-nr", none)
+
+/// The step the content being laid out right now first stands on.
+///
+/// Three cases, in this order. Inside a tracked element the stack says it.
+/// Inside a sprite, whose body is the same content laid out a second time, the
+/// element's own entry in `sprites` says it, and that still holds after a
+/// nested element has come and gone. Anywhere else, content stands from the
+/// first step.
+///
+/// Must be called inside a context.
+#let step-jetzt() = {
+  let stapel = step-here.get()
+  if stapel.len() > 0 { return calc.max(1, stapel.last()) }
+  let nr = sprite-number.get()
+  if nr == none { return 1 }
+  let liste = sprites.get()
+  if nr >= 1 and nr <= liste.len() { calc.max(1, liste.at(nr - 1).step) } else { 1 }
+}
+
 /// A name, however it was written.
 ///
 /// Names identify things across slides: a morph that flies, a frame that
@@ -316,8 +423,6 @@
     + "fr is shared out by the parent among its siblings, and a tracked "
     + "element is measured on its own. Put the fr outside the anim/stagger, "
     + "or give the element a container with a known size.")
-  if not html-output.get() { return body }
-  element-counter.step()
   // `auto` takes the next step. An explicit selector pulls the cursor up to its
   // own highest step, so whatever follows carries on after it instead of
   // starting over.
@@ -326,18 +431,47 @@
   // (they are there from the start), and above all they must not push the
   // bullets beside them along: in a two-column slide the text next to an
   // applet belongs at step one, not behind the applet's tweens.
-  if at == auto { step-cursor.step() }
+  //
+  // The cursor runs in *both* outputs, and that is why the accounting stands
+  // above the branch below. Nothing is revealed on paper, but `info().step`
+  // has to report the same count there as in the browser, and the count is
+  // what the cursor holds at the end of the slide. A counter update draws
+  // nothing, so the page is unchanged by it. Verified on the six example
+  // decks: every PDF page pixel for pixel as before.
+  //
+  // Assigned to a name here, but placed further down all the same: a counter
+  // only moves where its update stands in the document. Left in the `let` it
+  // would join into the value instead of reaching the page.
+  let zaehlen = if im-deck() {
+    if at == auto { step-cursor.step() }
+    else if kind == "anim" {
+      step-cursor.update(c => calc.max(c, max-step(selector(at))))
+    }
+  } else { [] }
+  // On paper there is no overlay, no marker and no reveal, so the body simply
+  // stands where Typst puts it. The counting above still has to reach the
+  // document, hence the joined return rather than a bare one.
+  if not html-output.get() { return zaehlen + body }
+  zaehlen
+  element-counter.step()
   context {
     let n = element-counter.get().first()
     let selected = if at == auto {
       str(step-cursor.get().first()) + "-"
     } else { selector(at) }
-    // Placed, not assigned: a counter only moves when its update stands in the
-    // document. Tucked into a `let` it would join into the value instead and
-    // turn the selector into content.
-    if at != auto and kind == "anim" {
-      step-cursor.update(c => calc.max(c, max-step(selected)))
-    }
+    // The step this element first stands on, and what `info().step.number`
+    // reads inside its body. It travels into the sprite as well, because the
+    // body is laid out a second time there, long after the cursor has run on
+    // to the end of the slide.
+    let erster = min-step(selected)
+    // Pushed *before* the layout, not inside the hidden block further down,
+    // and that is not cosmetic: the body is measured before it is laid out,
+    // and a measurement reads the state as it stands at that point in the
+    // document. Verified: content whose length depends on a state measures
+    // 20.23pt before the update and 112.26pt after it. Pushed any later, and
+    // the marker would reserve the room for a step number the body no longer
+    // prints.
+    step-here.update(a => a + (erster,))
     layout(available => context {
       // Measured under the same width the element has in the background. That
       // measurement travels outward so the sprite gets exactly the same
@@ -427,7 +561,7 @@
       sprites.update(a => a + ((kind: kind, at: selected, extra: extra, body: body,
                                 raw-frames: raw-frames, width: w,
                                 height: m.height, region: region, pad: luft,
-                                style: style),))
+                                step: erster, style: style),))
       // A `box` is inline and puts its baseline on the bottom edge, and with a
       // two-line list item the bullet would drop a line. Block content gets a
       // `block`.
@@ -448,6 +582,9 @@
           body)))
       })
     })
+    // The element is done, so whatever stood around it stands again. Popped,
+    // never assigned back from a remembered value: see `step-here`.
+    step-here.update(a => if a.len() > 0 { a.slice(0, -1) } else { a })
   }
   })
 }

--- a/src/layout.typ
+++ b/src/layout.typ
@@ -14,7 +14,7 @@
 // and only learns there under which theme it is set.
 
 #import "elements.typ": anim
-#import "internal.typ": step-cursor, zeilen-hoehe
+#import "internal.typ": step-cursor, umgebungs-block, zeilen-hoehe
 #import "config.typ": doc-word
 #import "themes.typ": theme-state
 
@@ -29,6 +29,13 @@
 /// No `clip: true`: Typst derives a clip path's identifier from the
 /// content, and the same box twice on a slide would produce the same
 /// identifier. The corners are therefore rounded by the bar itself.
+///
+/// Six labels for the six parts, so a deck can restyle them without touching
+/// the theme. `<ts-card>` is the box itself, and because its surface travels
+/// through a `set` rule rather than an argument, `set block(fill: ..)` on
+/// that label reaches it. `<ts-card-bar>` is the coloured tab, `<ts-card-title>`
+/// the caption, `<ts-card-disc>` the numbered disc, `<ts-card-number>` the
+/// numeral in it, `<ts-card-body>` the body.
 #let card(
   body,
   title: none,
@@ -68,23 +75,42 @@
   let radius = if radius != auto { radius } else if stil == "label" { 0pt } else { 7pt }
   let stroke = if stroke != auto { stroke }
                 else if stil == "label" { none } else { 0.7pt + t.border }
-  block(
+  // Surface, border and rounding travel through a `set` rule instead of
+  // standing as arguments on the block. Only that way does
+  // `show label("ts-card"): set block(fill: ..)` reach the box: an explicit
+  // argument beats any rule. What the surrounding document had set is read
+  // first and put back inside, or the box's own surface would run on into
+  // every block of its body and out over the rounded corners.
+  let aussen = umgebungs-block()
+  {
+  set block(fill: fill, stroke: stroke, radius: radius)
+  [#block(
     width: width, height: if zeile == none { auto } else { zeile },
-    radius: radius, fill: fill, stroke: stroke,
   {
     // Between the bar and the body, Typst would otherwise add its block
     // spacing: measured at 20pt for 17pt text, which left the text hanging
     // 30pt below the head but only 9pt above the bottom edge. Both blocks
     // give it up; the spacing comes solely from `inset`.
-    set block(spacing: 0pt)
+    set block(spacing: 0pt, fill: aussen.fill, stroke: aussen.stroke,
+              radius: aussen.radius)
     if title != none and stil == "bar" {
-      block(
-        width: 100%, fill: color,
-        radius: (top-left: radius, top-right: radius),
+      // No `stroke` here. The bar never had one of its own, so it picks up
+      // whatever the document set, and the line above has already put that
+      // back. Writing `stroke: none` would be an explicit value and would
+      // beat a deck's `#set block(stroke: ..)`, which is a change in a deck
+      // that uses no label at all.
+      set block(fill: color,
+                radius: (top-left: radius, top-right: radius))
+      [#block(
+        width: 100%,
         inset: (x: 11pt, y: 6pt),
-        text(size: 0.62em, weight: "bold", fill: white, tracking: 0.6pt,
-             upper(title)),
-      )
+        {
+          set block(fill: aussen.fill, stroke: aussen.stroke,
+                    radius: aussen.radius)
+          text(size: 0.62em, weight: "bold", fill: white, tracking: 0.6pt,
+               [#upper(title) <ts-card-title>])
+        },
+      ) <ts-card-bar>]
     }
     block(width: 100%, inset: inset, {
     // In the label style, the caption sits inside the box and shares the
@@ -92,28 +118,38 @@
     // white: here the label is a heading, not a tab.
     if title != none and stil == "label" {
       block(above: 0pt, below: 0.45em,
-        text(size: 0.78em, weight: "bold", fill: color, title))
+        text(size: 0.78em, weight: "bold", fill: color, [#title <ts-card-title>]))
     }
-    if number == none { body } else {
+    let rumpf = [#body <ts-card-body>]
+    if number == none { rumpf } else {
       grid(
         columns: (auto, 1fr), column-gutter: 8pt, align: (left + top, left + top),
-        box(baseline: 0.24em, circle(
-          radius: 0.62em, fill: color, stroke: none,
-          align(center + horizon,
-                text(size: 0.62em, weight: "bold", fill: white, str(number))),
-        )),
-        body,
+        box(baseline: 0.24em, {
+          set circle(fill: color, stroke: none)
+          [#circle(
+            radius: 0.62em,
+            align(center + horizon,
+                  text(size: 0.62em, weight: "bold", fill: white,
+                       [#str(number) <ts-card-number>])),
+          ) <ts-card-disc>]
+        }),
+        rumpf,
       )
     }
     })
   },
-  )
+  ) <ts-card>]
+  }
 }
 
 /// A highlighted key sentence: Beamer's `alertblock`.
 ///
 /// The bar on the left marks it on every slide at a glance as "the thing to
 /// remember", without it looking like a second box.
+///
+/// Labelled `<ts-callout>`, `<ts-callout-title>` and `<ts-callout-body>`. As
+/// in `card`, the surface goes through a `set` rule, so a label rule reaches
+/// `fill`, `stroke` and `radius`.
 #let callout(
   body,
   title: auto,
@@ -132,11 +168,16 @@
   let grund = if t.inverted { color.darken(68%) } else { color.lighten(90%) }
   let beschriftung = if t.inverted { color.lighten(15%) } else { color.darken(12%) }
   let zeile = zeilen-hoehe.get()
-  block(
+  // As in `card`: the surface goes through a rule so a label can reach it,
+  // and the document's own block style is put back inside.
+  let aussen = umgebungs-block()
+  {
+  set block(fill: grund, stroke: (left: 3.5pt + color), radius: radius)
+  [#block(
     width: width, height: if zeile == none { auto } else { zeile },
-    radius: radius, fill: grund,
-    stroke: (left: 3.5pt + color), inset: inset,
+    inset: inset,
     {
+      set block(fill: aussen.fill, stroke: aussen.stroke, radius: aussen.radius)
       // Not text, `v()` and body one after another: between two paragraphs
       // Typst additionally inserts `par.spacing`, 29pt for 24pt text, which
       // adds to the explicit spacing. Measured at 34pt instead of the
@@ -145,15 +186,17 @@
       if title != none {
         block(above: 0pt, below: 0pt,
           text(size: 0.62em, weight: "bold", fill: beschriftung,
-               tracking: 0.6pt, upper(title)))
+               tracking: 0.6pt, [#upper(title) <ts-callout-title>]))
       }
       // Relative to the text size, so the spacing is right at every theme
       // size: fixed points would look too airy at 15pt and cramped at 31pt.
       // More air than in the box: there the colored bar separates label and
       // text, here both sit on the same background and need the spacing.
-      block(above: if title == none { 0pt } else { 0.6em }, below: 0pt, body)
+      block(above: if title == none { 0pt } else { 0.6em }, below: 0pt,
+        [#body <ts-callout-body>])
     },
-  )
+  ) <ts-callout>]
+  }
 }
 
 /// Two or more columns side by side.
@@ -259,17 +302,20 @@
 /// Explicitly demands the full width: a tracked element becomes as wide
 /// as its content, and a bare `align(center, …)` inside it would have no
 /// room to center in and would sit unchanged on the left.
+///
+/// Labelled `<ts-statement>`. `size` is measured in `em`, so a
+/// `set text(size: …)` from a label rule multiplies rather than replaces it.
 #let statement(
   body,
   size: 1.6em,
   color: none,
   above: 0.6em,
   below: 0.6em,
-) = block(width: 100%, {
+) = [#block(width: 100%, {
   v(above)
   // `fill: auto` does not exist for `text`: without a color, none is set
   // at all, so that the surrounding one applies.
   let gesetzt = text(size: size, body)
   align(center, if color == none { gesetzt } else { text(fill: color, gesetzt) })
   v(below)
-})
+}) <ts-statement>]

--- a/src/layout.typ
+++ b/src/layout.typ
@@ -18,7 +18,7 @@
                         hat-pause, im-fit, step-cursor, umgebungs-block,
                         unloesbar, zeilen-hoehe)
 #import "config.typ": doc-word
-#import "themes.typ": theme-state
+#import "themes.typ": lesbar, theme-state
 
 /// A named box: Beamer's `block`.
 ///
@@ -64,7 +64,15 @@
   // far below the slide.
   let zeile = zeilen-hoehe.get()
   let eigene-farbe = color != auto
-  let color = if color == auto { t.strong } else { color }
+  // In the bar style the color is a *ground* and carries white on it, so it
+  // has to stay the theme's strong tone. In the label style the same entry is
+  // *text* on the surface, and there the strong tone of a dark palette sits
+  // too close to that surface to be read. So that one is measured rather than
+  // named. Where the theme's own colors already work, and they do in all five,
+  // the measurement returns exactly what stood here before.
+  let color = if color != auto { color } else if stil == "label" {
+    lesbar(t.surface, t.strong, t.ink)
+  } else { t.strong }
   // In the label style, the tint carries the same meaning as the text on
   // it: a box labeled in blue sits on blue, a red one on red. Only someone
   // giving no color gets `surface`: in the textbook theme that is the

--- a/src/layout.typ
+++ b/src/layout.typ
@@ -14,7 +14,9 @@
 // and only learns there under which theme it is set.
 
 #import "elements.typ": anim
-#import "internal.typ": step-cursor, umgebungs-block, zeilen-hoehe
+#import "internal.typ": (fit-faktor, fit-mass, fit-meldung, fit-toleranz,
+                        hat-pause, im-fit, step-cursor, umgebungs-block,
+                        unloesbar, zeilen-hoehe)
 #import "config.typ": doc-word
 #import "themes.typ": theme-state
 
@@ -274,6 +276,9 @@
   enter: "fade-up",
   align: top + left,
 ) = context {
+  // Asked here rather than left to the `anim`s below, so the message names the
+  // function the deck actually wrote.
+  assert(im-fit.get() == 0, message: fit-meldung("tiles"))
   let kacheln = items.pos()
   assert(kacheln.len() > 0, message: "typstage: tiles() wants at least one tile")
   assert(at == auto or type(at) == int,
@@ -319,3 +324,123 @@
   align(center, if color == none { gesetzt } else { text(fill: color, gesetzt) })
   v(below)
 }) <ts-statement>]
+
+/// Scale one block down to the room it has.
+///
+/// For the thing whose size the deck does not control: a wide table, a
+/// generated diagram, a list that came out of a data file. Without it such a
+/// block runs over the edge of the slide. In the PDF it is still to be seen
+/// standing there; in the browser the slide sits in a frame of fixed size and
+/// whatever reaches past it is cut away.
+///
+/// ```typ
+/// #slide[
+///   == Regression results
+///   #fit(wrap: false, my-table)
+/// ]
+/// ```
+///
+/// `wrap: false` because the block is a table. Everything that lays itself out
+/// in columns has to be measured as it stands; see below.
+///
+/// The block is measured against the place it stands in and scaled
+/// geometrically, so it keeps its proportions and what stands around it counts
+/// with its new size. No factor is given by hand.
+///
+/// *Width first, then smaller.* The block is offered the full width before it
+/// is measured, so a paragraph or a list breaks into the space instead of
+/// shrinking, and only what is still too tall afterwards is scaled. A table, a
+/// chart or a drawing would rearrange its own columns instead, which changes
+/// the picture rather than its size; `wrap: false` measures such a block
+/// exactly as it stands.
+///
+/// *It only shrinks.* `grow: true` also blows a block up that is smaller than
+/// its place, for the one large number that is meant to fill the slide.
+/// `shrink: false` takes the shrinking away and leaves only the growing.
+///
+/// `width` and `height` take `auto`, a length or a ratio. `auto` is the whole
+/// place. On `height: auto` the block takes what is left over below whatever
+/// stands above it on the slide, so a fit under two bullet points reckons with
+/// the bullet points. That has a flip side wherever something encloses the
+/// fit: inside a `card` the box becomes slide-tall, is cut off at the bottom,
+/// and *whatever follows the card falls off the slide* -- measured in both
+/// outputs. It is the `1fr` doing that, not the scaling: a `card` around a
+/// bare `block(height: 1fr)` behaves the same. Give `height:` explicitly
+/// inside a card, and the fit reckons with that instead.
+///
+/// *No reveal inside.* Two things do not survive being measured. A `pause` is
+/// found by walking the slide body, and a fitted block is a closure that walk
+/// cannot enter: measured on a slide carrying two pauses, the step count fell
+/// from three to one and nothing said so. And a measured block has no height
+/// to reckon against, which is the axis on which a tracked element resolves
+/// its size and reserves the room for its marker: measured, an `anim` inside a
+/// fit was not scaled at all and ran off the bottom of the slide. `fit` stops
+/// with a message instead, for `pause`, `anim`, `stagger`, `alternatives`,
+/// `morph`, `tiles`, `video`, `embed` and `flipbook`, in both outputs. Fit
+/// what stands inside the reveal rather than fitting around it:
+/// `anim(fit(my-table))` works, `fit(anim(my-table))` is the error.
+///
+/// `speaker-note` and `bridge-job` are allowed inside a fit. They settle no
+/// geometry, and a `measure` commits no state, so both were measured to arrive
+/// exactly once. The other direction is the one that does not work: a note
+/// made only of a `fit` carries no text, and `speaker-note` refuses it.
+///
+/// The geometry is adapted from mosaic, which adapted Touying 0.7.4, which
+/// credits it to Andreas Kröpelin (Polylux PR #91) and to ntjess.
+#let fit(
+  body,
+  width: auto,
+  height: auto,
+  wrap: true,
+  grow: false,
+  shrink: true,
+) = {
+  // Asked before anything is laid out, and by walking the body, because a
+  // pause is a marker and not a call. Everything else announces itself while
+  // it is laid out and is caught by `im-fit`.
+  assert(not hat-pause(body), message: fit-meldung("pause"))
+  im-fit.update(d => d + 1)
+  let gebaut = layout(reg => context {
+    // No room means nothing to solve. That is not an exotic case: under a
+    // `measure` the region comes back unbounded, and `alternatives` and
+    // `side-by-side(equal: true)` both measure their content.
+    if unloesbar(reg.width) or unloesbar(reg.height) { return body }
+    let raum-b = fit-mass(width, reg.width)
+    let raum-h = fit-mass(height, reg.height)
+    if unloesbar(raum-b) or unloesbar(raum-h) { return body }
+    // The full width first, so text breaks instead of shrinking. Capped at the
+    // block's own width, or a single short line would be stretched across the
+    // slide and then measured as if it were that wide.
+    let inhalt = if wrap {
+      box(width: calc.min(raum-b, measure(body).width), body)
+    } else { body }
+    let mass = measure(inhalt)
+    // Something without an area has no factor. A line measures 0pt tall, and
+    // dividing by that would end the compilation.
+    if mass.width <= 0pt or mass.height <= 0pt { return body }
+    let f = fit-faktor(mass, raum-b, raum-h)
+    let anfassen = ((shrink and f < 100% - fit-toleranz)
+                    or (grow and f > 100% + fit-toleranz))
+    if anfassen {
+      scale(f, origin: top + left, reflow: true, box(width: mass.width, inhalt))
+    } else if width == auto {
+      // Untouched, not the measured box. `width: auto` is the region's own
+      // width, which the body gets from the region anyway, so a block that
+      // needs no scaling should stand exactly as it would without the fit.
+      // Measured on a paragraph that wraps into its place: the pixels of the
+      // slide with the fit and of the slide without it are the same.
+      body
+    } else {
+      // A width given by hand has to hold even when nothing is scaled, or the
+      // argument would do nothing at all in that case. Measured: without this,
+      // `fit(width: 50%, table)` set the table across the full slide.
+      inhalt
+    }
+  })
+  // `1fr` is what turns "the whole height" into "what is left over": in a flow
+  // the fixed-size siblings are laid out first and the fraction takes the
+  // rest, so a fit below two bullet points reckons with them. Only for
+  // `height: auto`; a height given by hand is meant literally.
+  if height == auto { block(height: 1fr, gebaut) } else { gebaut }
+  im-fit.update(d => d - 1)
+}

--- a/src/layout.typ
+++ b/src/layout.typ
@@ -404,6 +404,16 @@
     // No room means nothing to solve. That is not an exotic case: under a
     // `measure` the region comes back unbounded, and `alternatives` and
     // `side-by-side(equal: true)` both measure their content.
+    //
+    // A hand-given height is not asserted here either, and that was tried.
+    // Handing back `block(height: height, body)` looks right for the one case
+    // where the fit really does scale the body down to it, but it is a claim
+    // the fit does not keep: with a body smaller than the height nothing is
+    // grown, with `shrink: false` nothing is shrunk, and under a narrower
+    // region the width decides the factor and the block ends up shorter than
+    // the height. Measured, `fit(height: 300pt)` around a small body reserved
+    // 300pt where 7.24pt is set, and an `alternatives` beside such a fit
+    // pushed the rest of the slide to its bottom edge.
     if unloesbar(reg.width) or unloesbar(reg.height) { return body }
     let raum-b = fit-mass(width, reg.width)
     let raum-h = fit-mass(height, reg.height)

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -22,7 +22,7 @@
   info,
 )
 #import "elements.typ": alternatives, anim, morph, pause, pin, stagger
-#import "layout.typ": card, callout, side-by-side, statement, tiles
+#import "layout.typ": card, callout, fit, side-by-side, statement, tiles
 #import "media.typ": video, embed, flipbook
 #import "bridge.typ": bridge-job, bridge-targets
 #import "present.typ": presentation, bundle

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -15,8 +15,15 @@
 )
 
 #import "themes.typ": theme, themes
+#import "palettes.typ": (
+  // Color as a thing of its own, and the instrument the bundled palettes are
+  // measured with.
+  palettes, contrast, palette-report,
+)
 #import "slides.typ": (
   slide, section, title-slide, transition, speaker-note,
+  // One slide in the palette turned around, for the heading notation.
+  invert,
   // What the deck knows about itself, so a deck can build its own chrome
   // instead of forking the theme.
   info,

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -15,7 +15,12 @@
 )
 
 #import "themes.typ": theme, themes
-#import "slides.typ": slide, section, title-slide, transition, speaker-note
+#import "slides.typ": (
+  slide, section, title-slide, transition, speaker-note,
+  // What the deck knows about itself, so a deck can build its own chrome
+  // instead of forking the theme.
+  info,
+)
 #import "elements.typ": alternatives, anim, morph, pause, pin, stagger
 #import "layout.typ": card, callout, side-by-side, statement, tiles
 #import "media.typ": video, embed, flipbook

--- a/src/media.typ
+++ b/src/media.typ
@@ -1,8 +1,8 @@
 // Video, embedded documents and Typst-drawn animation, plus what takes their
 // place on paper.
 
-#import "internal.typ": (track, bridge-jobs, html-output, im-deck, name-of,
-                         step-cursor, slide-counter)
+#import "internal.typ": (track, bridge-jobs, fit-verbot, html-output, im-deck,
+                         name-of, step-cursor, slide-counter)
 #import "config.typ": doc-word
 
 /// The box that stands in for a moving element in the PDF.
@@ -127,6 +127,9 @@
   // companion package resolving `target: auto` has to find an applet that is
   // written *below* its own commands as well.
   let bridge = if bridge == none { none } else { name-of(bridge) }
+  // On paper `embed` never reaches `track`, it only draws its stand-in and
+  // moves the cursor, so the fit check cannot be left to `track` here.
+  fit-verbot("embed")
   if bridge != none {
     context [#metadata((
       slide: slide-counter.get().first(), name: bridge,
@@ -166,7 +169,10 @@
   at: "1-",
   enter: "fade",
   still: auto,
-) = context if not html-output.get() {
+) = {
+  // As in `embed`: on paper this never reaches `track`.
+  fit-verbot("flipbook")
+  context if not html-output.get() {
   // On paper a single frame has to do. `still` picks which one.
   // The step counting of `track` does not run here, so the one case that
   // consumes a step is done by hand, as in `embed`.
@@ -199,4 +205,5 @@
              else { i / (frames - 1) }),
     )),
   )
+}
 }

--- a/src/media.typ
+++ b/src/media.typ
@@ -10,24 +10,32 @@
 /// `fallback` is arbitrary content: a CeTZ drawing, an image, a table. Left
 /// out, a labelled placeholder remains. `link` goes underneath and is
 /// clickable in the PDF: whoever holds the handout gets to the live thing.
-#let fallback-box(fallback, link-target, width, height, label) = block(
+///
+/// Labelled `<ts-media-fallback>`. The outer block is only a container and
+/// carries no surface of its own; the grey box that appears when no
+/// `fallback` was given is `<ts-media-fallback-empty>` and has one.
+#let fallback-box(fallback, link-target, width, height, label) = [#block(
   width: width, height: height, {
     let main = if link-target == none { 100% } else { 88% }
     if fallback != none {
       block(width: 100%, height: main, align(center + horizon, fallback))
     } else {
-      block(width: 100%, height: main, fill: luma(95%),
-            stroke: 0.5pt + luma(80%), radius: 4pt,
-            align(center + horizon, text(size: 0.75em, fill: luma(45%), label)))
+      set block(fill: luma(95%), stroke: 0.5pt + luma(80%), radius: 4pt)
+      [#block(width: 100%, height: main,
+              align(center + horizon, text(size: 0.75em, fill: luma(45%), label)))
+       <ts-media-fallback-empty>]
     }
     if link-target != none {
       align(center, text(size: 0.62em, fill: luma(45%),
                          link(link-target, link-target)))
     }
   },
-)
+) <ts-media-fallback>]
 
 /// A real HTML5 video over the slide.
+///
+/// Without a `poster:` the placeholder on paper is labelled
+/// `<ts-media-poster>`.
 #let video(
   src,
   width: 100%,
@@ -43,7 +51,10 @@
 ) = track(
   "video",
   box(width: width, height: height, clip: true, radius: radius,
-      if poster == none { rect(width: 100%, height: 100%, fill: luma(92%)) } else {
+      if poster == none {
+        set rect(fill: luma(92%))
+        [#rect(width: 100%, height: 100%) <ts-media-poster>]
+      } else {
         { set image(width: 100%, height: 100%, fit: "cover"); poster }
       }),
   at: at,

--- a/src/media.typ
+++ b/src/media.typ
@@ -1,8 +1,8 @@
 // Video, embedded documents and Typst-drawn animation, plus what takes their
 // place on paper.
 
-#import "internal.typ": (track, bridge-jobs, html-output, name-of,
-                         slide-counter)
+#import "internal.typ": (track, bridge-jobs, html-output, im-deck, name-of,
+                         step-cursor, slide-counter)
 #import "config.typ": doc-word
 
 /// The box that stands in for a moving element in the PDF.
@@ -133,6 +133,10 @@
     ))<typstage-bridge-target>]
   }
   context if not html-output.get() {
+  // The step counting of `track` does not run on paper, so the one case that
+  // consumes a step is done here: `info().step.total` has to report the same
+  // number in both outputs.
+  if at == auto and im-deck() { step-cursor.step() }
   fallback-box(fallback, if link != none { link } else { url }, width, height,
                if label == auto { doc-word("embedded") } else { label })
 } else {
@@ -164,6 +168,9 @@
   still: auto,
 ) = context if not html-output.get() {
   // On paper a single frame has to do. `still` picks which one.
+  // The step counting of `track` does not run here, so the one case that
+  // consumes a step is done by hand, as in `embed`.
+  if at == auto and im-deck() { step-cursor.step() }
   block(width: width, height: height,
         if still == auto { render(0.0) } else { still })
 } else {

--- a/src/palettes.typ
+++ b/src/palettes.typ
@@ -1,0 +1,249 @@
+// Colour as a thing of its own: the palettes, the contrast contract they are
+// held to, and the derivation an inverted slide uses.
+//
+// A theme says how a slide is *built*; a palette says what colour it is. The
+// two vary separately: the classroom look is still the classroom look in a
+// darkened room. That is why there is no second dark theme for every design
+// here. Darkness is a palette, not a design.
+//
+// One rule shapes this file, and it is the reason the contract exists at all:
+// no colour is ever guessed from the lightness of another. A muted sage such
+// as rgb("#aebdb3") reads as "light" to a luminance rule, yet white on it
+// measures 1.96 to 1 by the arithmetic below, far under the 4.5 to 1 that body
+// text wants. What `invert-palette` derives, it derives from *two* given
+// colours, the ground and the text, never from one alone.
+
+/// One sRGB channel, linearised the way WCAG 2 defines it.
+///
+/// The value comes in as a ratio from 0 to 1, not as a byte.
+#let kanal(c) = if c <= 0.03928 { c / 12.92 } else {
+  calc.pow((c + 0.055) / 1.055, 2.4)
+}
+
+/// Relative luminance of a colour, WCAG 2.
+///
+/// Deliberately not `color.luma`. That one turns a color into a grey and hands
+/// back a gamma-encoded value, 72.64 percent for the sage above, where the
+/// relative luminance below is 0.4865. The first number answers "does this
+/// look light", which it does; the second answers "can this be read on it",
+/// and that is the question a contrast contract asks.
+#let leuchtdichte(c) = {
+  let (r, g, b) = rgb(c).components(alpha: false).map(x => kanal(x / 100%))
+  0.2126 * r + 0.7152 * g + 0.0722 * b
+}
+
+/// The WCAG contrast ratio of two colours, a number from 1 to 21.
+///
+/// ```typ
+/// #contrast(black, white)                 // 21
+/// #contrast(rgb("#767b84"), white)        // 4.2539
+/// ```
+///
+/// The reference numbers WCAG 2 names: 4.5 for body text, 3.0 for large text
+/// and for lines, bars and other shapes that are not text. The package uses
+/// them in that sense in `palette-report`.
+///
+/// Alpha is ignored. A translucent colour is measured as if it were opaque,
+/// which is not what it looks like on the slide.
+#let contrast(a, b) = {
+  let (x, y) = (leuchtdichte(a), leuchtdichte(b))
+  (calc.max(x, y) + 0.05) / (calc.min(x, y) + 0.05)
+}
+
+/// The eight entries a palette may carry.
+#let palette-keys = (
+  "paper", "ink", "strong", "accent", "muted", "surface", "border", "inverted",
+)
+
+/// Refuse a palette with an entry that is not one of the eight.
+///
+/// Without this, `palette: (acent: blue)` would do nothing at all and say
+/// nothing about it.
+#let palette-pruefen(p) = {
+  assert(type(p) == dictionary, message:
+    "typstage: palette takes a dictionary of colours, not " + str(type(p)))
+  for k in p.keys() {
+    assert(k in palette-keys, message:
+      "typstage: a palette has no entry \"" + k + "\". It takes "
+      + palette-keys.join(", ") + ".")
+  }
+  p
+}
+
+/// The palette an inverted slide is set in.
+///
+/// The ground becomes the palette's text colour and the text becomes its
+/// ground. `muted`, `surface` and `border` are mixed from those two, so they
+/// keep their relation to both. `strong` and `accent` carry over unchanged:
+/// the accent is the deck's signal colour and must not turn into a different
+/// colour halfway through the talk.
+///
+/// The mixing happens in sRGB, not in the Oklab space `color.mix` would take
+/// by default. Measured on a palette with pure black ink, at the same
+/// percentages as below: in Oklab the derived surface comes out as #010101 and
+/// the derived border as #151515, which is 1.15 to 1 against the ground, a
+/// hairline nobody sees. In sRGB the same two are #131313 and #313131, and the
+/// border measures 1.62 to 1. Oklab compresses hard near black, and that is
+/// exactly where a derived dark palette lives.
+///
+/// The percentages were set by measurement, not by eye. At 24 percent the
+/// derived border measures between 1.51 and 1.84 to 1 against the derived
+/// ground across the five bundled palettes, and the tightest of those is the
+/// dark palette. 42 percent for the muted grey holds it between 6.47 and
+/// 10.08, well clear of the 4.5 the contract wants.
+#let invert-palette(p) = {
+  let grund = p.ink
+  let satz = p.paper
+  (
+    paper: grund,
+    ink: satz,
+    muted: satz.mix((grund, 42%), space: rgb),
+    surface: grund.mix((satz, 8%), space: rgb),
+    border: grund.mix((satz, 24%), space: rgb),
+    strong: p.strong,
+    accent: p.accent,
+    inverted: not p.at("inverted", default: false),
+  )
+}
+
+/// The contract, as data: pair, floor, and what the pair is for.
+///
+/// `accent on ink` is the odd one and the reason it is in here: on an inverted
+/// slide the ink is what ends up behind the accent, so an accent tuned for one
+/// ground alone would go dim there without a word.
+#let vertrag = (
+  (a: "ink", b: "paper", min: 4.5, was: "body text on the slide"),
+  (a: "ink", b: "surface", min: 4.5, was: "body text in a card"),
+  (a: "muted", b: "paper", min: 4.5, was: "footer, subtitle, running head"),
+  (a: "accent", b: "paper", min: 3.0, was: "rules, progress bar, marker"),
+  (a: "accent", b: "ink", min: 3.0, was: "the same on an inverted slide"),
+  (a: "border", b: "paper", min: 1.2, was: "hairlines"),
+)
+
+/// Measure a palette against the contrast contract and report every pair.
+///
+/// ```typ
+/// #for f in palette-report(palettes.dark) [
+///   #f.pair: #calc.round(f.ratio, digits: 2) (wants #f.min) #f.ok \
+/// ]
+/// ```
+///
+/// One dictionary per pair, with `pair`, `ratio`, `min`, `ok` and `role`. It
+/// only measures and never changes a colour.
+///
+/// This is a report, not a gate. Only the five bundled palettes are actually
+/// held to the contract, by an assertion in this file; a palette written in a
+/// deck faces no such check, and none of the five bundled *themes* does
+/// either. Four of the five do not pass it, and that is deliberate rather than
+/// overlooked. See the manual.
+#let palette-report(p) = vertrag.map(v => {
+  let r = contrast(p.at(v.a), p.at(v.b))
+  (pair: v.a + " on " + v.b, ratio: r, min: v.min, ok: r >= v.min, role: v.was)
+})
+
+/// The bundled palettes.
+///
+/// Five, one per colour world the package already had, and each of them
+/// composes with every theme: `themes.lesson` in `palettes.dark` is still the
+/// lesson design, only dark.
+///
+/// - `light` is exactly the default theme's colours, so
+///   `themes.default` with it is a no-op.
+/// - `mono` is `themes.plain`'s greyscale, with two greys moved so it passes
+///   the contract.
+/// - `textbook` is `themes.lesson`'s measured textbook colours, with `muted`
+///   moved for the same reason.
+/// - `parchment` is `themes.editorial`'s laid paper, with `accent` and `muted`
+///   moved for the same reason.
+/// - `dark` is `themes.night`'s dark ground with a deeper accent, because
+///   night's own cyan does not survive an inverted slide.
+///
+/// The six numbers that were moved, and why, are in the comments below.
+#let palettes = (
+  // The default look. Not a colour of it is changed, so this palette is the
+  // one that changes nothing.
+  light: (
+    paper: rgb("#fafafa"), ink: black, strong: rgb("#23303f"),
+    accent: rgb("#eb5e28"), muted: luma(45%), surface: white,
+    border: luma(84%), inverted: false,
+  ),
+
+  // Greyscale, the plain theme's world. Two changes against `themes.plain`.
+  // Its muted grey is luma(55%) and measures 3.35 to 1 on white, under the
+  // 4.5 that a footer wants; luma(45%) measures 4.76. And its accent equals
+  // its strong, luma(12%), which measures 1.27 to 1 on black and would be
+  // gone on an inverted slide; luma(40%) measures 5.74 on white and 3.66 on
+  // black, so it holds on both grounds. That window is narrow for a grey:
+  // anything readable on white and on black has to sit in the middle.
+  mono: (
+    paper: white, ink: black, strong: luma(12%), accent: luma(40%),
+    muted: luma(45%), surface: white, border: luma(86%), inverted: false,
+  ),
+
+  // The German maths textbook, measured for `themes.lesson` from a sample
+  // page of "Fundamente der Mathematik". Vermilion for "this you must know",
+  // cyan blue for "this is what it looks like", and the warm tint of the note
+  // box. One change: the theme's muted #767b84 measures 4.25 to 1 on white,
+  // and the running header sets the slide number in it. #6f747d is the same
+  // grey seven points darker in every channel and measures 4.70.
+  textbook: (
+    paper: white, ink: rgb("#16181c"), strong: rgb("#c1361c"),
+    accent: rgb("#2b7fb8"), muted: rgb("#6f747d"), surface: rgb("#fdf6ee"),
+    border: rgb("#f0e2d2"), inverted: false,
+  ),
+
+  // Laid paper and an old-style serif, the editorial world. Two changes. The
+  // theme's accent #b4894a measures 2.84 to 1 on its paper, under the 3.0 a
+  // hairline wants; #9a6f2f measures 4.01. And its muted #8a7f70 measures
+  // 3.51 where the byline stands; #736858 measures 4.88. Both stay the same
+  // hue, only deeper.
+  parchment: (
+    paper: rgb("#f7f2e6"), ink: rgb("#2a2622"), strong: rgb("#7b2d26"),
+    accent: rgb("#9a6f2f"), muted: rgb("#736858"), surface: rgb("#fffdf7"),
+    border: rgb("#ded2ba"), inverted: false,
+  ),
+
+  // The dimmed room. One change against `themes.night`, and it is the finding
+  // this contract was built to catch: night's cyan #5ec8f2 measures 9.77 to 1
+  // on the dark ground, which is why it glows there, but only 1.59 to 1 on
+  // night's own ink, which is the ground an inverted slide puts behind it. Any
+  // colour that holds on both has to sit between roughly 0.13 and 0.23 in
+  // relative luminance; #5ec8f2 sits at 0.52. #2b8ab5 measures 4.79 on the
+  // dark ground and 3.24 on the light one. It does not glow, and that is the
+  // price of the guarantee. `themes.night` keeps its own cyan.
+  dark: (
+    paper: rgb("#0f1319"), ink: rgb("#e6ebf2"), strong: rgb("#2c3644"),
+    accent: rgb("#2b8ab5"), muted: rgb("#8f9bab"), surface: rgb("#1a212b"),
+    border: rgb("#2e3947"), inverted: true,
+  ),
+)
+
+// The contract, enforced. Runs once when this module is loaded, over each
+// bundled palette and over its inverted form, so a colour changed here cannot
+// reach a deck without the arithmetic having seen it.
+//
+// In Typst rather than in a test script of its own, for two reasons. The
+// package has no test chain, and one that nobody runs before a release is
+// worse than none. And the check has to measure what *Typst* produced: the
+// derived colours above come out of `color.mix`, and re-implementing that in
+// another language would be the likeliest place for the two to disagree.
+//
+// What it costs, measured: it is one pass of arithmetic over 5 palettes times
+// 2 forms times 6 pairs. Ten builds of the `theme-default` deck, three rounds
+// alternating with the version before this file existed, came to 0.196 to
+// 0.198 seconds per build without it and 0.198 to 0.201 with it. That is
+// inside the spread of the measurement, not a cost that shows.
+#let vertrag-geprueft = {
+  let pruefen(name, p) = {
+    for f in palette-report(p).filter(f => not f.ok) {
+      assert(false, message: "typstage: palettes." + name + " misses the "
+        + "contrast contract. " + f.pair + " measures "
+        + str(calc.round(f.ratio, digits: 2)) + " to 1, and " + f.role
+        + " wants at least " + str(f.min) + " to 1.")
+    }
+  }
+  for (name, p) in palettes.pairs() {
+    pruefen(name, p)
+    pruefen(name + " inverted", invert-palette(p))
+  }
+}

--- a/src/present.typ
+++ b/src/present.typ
@@ -475,6 +475,15 @@
               .map(sp => (slide: here, name: sp.extra.name,
                           ab-eins: ab-schritt-eins(sp.at)))
             morph-index.update(a => a + meine-morphs)
+            // The same for every element that wants to rest dimmed. Its
+            // range is closed -- `anim` insists on that -- but a closed range
+            // can still end with the slide, and then there is no step left to
+            // be dim on.
+            let meine-dims = sprites.get()
+              .filter(sp => sp.extra.at("after", default: none) == "dimmed"
+                            and not sp.at("dim-freiwillig", default: false))
+              .map(sp => (slide: here, bis: max-step(sp.at)))
+            dim-index.update(a => a + meine-dims)
             html.elem("script", attrs: (class: "ts-bridge", type: "application/json"),
                       json.encode(bridge-jobs.get()))
           }
@@ -499,6 +508,25 @@
     // of the same name. Otherwise the flight between the two is lost, and
     // silently: there is no error message, the formula simply appears
     // instead of flying. Hence an announcement here at compile time.
+    // An element that asked to rest dimmed but whose range ends with the
+    // slide never dims, and without this it would say nothing at all -- the
+    // author would get exactly `at: "1-"` and no hint why.
+    context {
+      for d in dim-index.get() {
+        let ende = query(<typstage-slide-end>).find(e => e.value == d.slide)
+        let gesamt = if ende == none { 1 } else {
+          calc.max(1, step-cursor.at(ende.location()).first())
+        }
+        assert(d.bis < gesamt, message:
+          "typstage: anim(after: \"dimmed\") on slide " + str(d.slide)
+          + " has a range that ends with the slide: it runs to step "
+          + str(d.bis) + " and the slide has " + str(gesamt)
+          + ". There is no step left for the element to be dim on, so it "
+          + "would behave exactly like the default and nothing would say so. "
+          + "Give the slide a further step, or drop the after.")
+      }
+    }
+
     context {
       let alle-morphs = morph-index.get()
       for m in alle-morphs.filter(m => not m.ab-eins) {

--- a/src/present.typ
+++ b/src/present.typ
@@ -192,6 +192,35 @@
 /// The PDF is a handout: one page per slide, every tracked element in its
 /// final state. What belongs only to the motion, the notes, the slide transitions,
 /// the bridge jobs, are state updates without output and fall away by themselves.
+///
+/// `overflow` is a checking pass over the deck, off by default. It measures
+/// every slide body against the room the theme gives it and names the ones
+/// that do not fit, with the earliest step on which the overrun can be on the
+/// screen. Title and section slides are not measured: the theme draws them
+/// with `place` and they have no body block.
+///
+/// - `"none"`: nothing is measured. The default.
+/// - `"error"`: the whole deck is built, and it then stops with *every* place
+///   at once rather than the first.
+/// - `"record"`: it carries on and files a record per finding instead, for a
+///   tool to read. The deck has to be on `"record"` for this; on `"error"`
+///   the command below stops with the error too:
+///
+/// ```sh
+/// typst eval --target html --features html --in deck.typ \
+///   'query(<typstage-overflow>).map(e => e.value)'
+/// ```
+///
+/// It is not meant to stay on while writing. Measured over the six example
+/// decks: in HTML it costs noticeably more time, between 1.2 and 1.5 times
+/// depending on the deck and on how the process start is accounted for. On
+/// paper it costs a few milliseconds per deck, small but repeatable: there the
+/// check runs without the step arithmetic.
+///
+/// Why a deck of slides needs this more than a document does: a slide goes
+/// into an SVG frame of fixed size and is scaled in the browser, so what
+/// sticks out is cut away or drawn beside the slide. A page one leafs through
+/// shows an overrun; a talk one clicks through shows it at the projector.
 #let presentation(
   ..slides,
   title: none,
@@ -208,7 +237,11 @@
   height: auto,
   margin: auto,
   handout: false,
+  overflow: "none",
 ) = {
+  assert(overflow in ("none", "error", "record"), message:
+    "typstage: overflow is \"none\" (the default), \"error\" or \"record\", "
+    + "not " + repr(overflow))
   // 16:9 on an A4-width canvas unless told otherwise. 4:3 is
   // `width: 800pt, height: 600pt`; everything the theme draws scales along.
   let geo = canvas(width: width, height: height, margin: margin)
@@ -275,7 +308,8 @@
            message: "typstage: handout takes true or 1 to 6 slides per page")
     theme-state.update(theme)
     html-output.update(false)
-    handout-body(all, facts, style, geo, theme, per)
+    handout-body(all, facts, style, geo, theme, per, overflow: overflow)
+    ueberlauf-bericht(overflow)
   } else if target() != "html" {
     set page(width: geo.width, height: geo.height, margin: 0pt)
     theme-state.update(theme)
@@ -300,9 +334,10 @@
                  // its last value standing.
                  + step-here.update(())
                  + sprite-number.update(none)
-                 + slide-body(s, style, geo, theme))
+                 + slide-body(s, style, geo, theme, overflow: overflow))
     }
     pages.join(pagebreak(weak: true))
+    ueberlauf-bericht(overflow)
   } else {
     html-output.update(true)
     theme-state.update(theme)
@@ -352,7 +387,8 @@
         // while the frame is laid out would be entered any more.
         html.elem("section", attrs: (class: "ts-slide"), {
           html.elem("div", attrs: (class: "ts-bg"),
-                    html.frame(slide-body(s, style, geo, theme, chrome: false)))
+                    html.frame(slide-body(s, style, geo, theme, chrome: false,
+                                          overflow: overflow)))
           // Second chrome, only for the print view (key `p`). There each
           // slide stands on its own page, there is no transition. And the
           // layer above the stage cannot travel along there, because the
@@ -419,6 +455,10 @@
           + "word. Either drop the `at:` here, or rename one of the two.")
       }
     }
+
+    // Read back at the end of the deck, not at the first finding: whoever runs
+    // the check before a talk wants the whole list in one go.
+    ueberlauf-bericht(overflow)
 
     html.elem("div", attrs: (id: "ts-overview"), [])
     html.elem("div", attrs: (id: "ts-hint"), [])

--- a/src/present.typ
+++ b/src/present.typ
@@ -4,7 +4,8 @@
 #import "internal.typ": *
 #import "slides.typ": *
 #import "theme.typ": handout-body, slide-body, slide-chrome
-#import "themes.typ": theme-state, themes
+#import "themes.typ": mit-palette, theme-state, themes
+#import "palettes.typ": palette-pruefen
 #import "render.typ": *
 #import "elements.typ": anim, pause
 
@@ -189,6 +190,27 @@
 /// `themes.night + (accent: blue)`. The `style` hook stays untouched by this
 /// and sits further *inside*: whatever is set there overrides the theme.
 ///
+/// `palette:` changes the colors and leaves the design alone. It is a
+/// dictionary over the eight color entries and it overwrites *partially*, so
+/// `palette: (accent: blue)` moves the accent and nothing else. Five are
+/// bundled, `palettes.light`, `palettes.mono`, `palettes.textbook`,
+/// `palettes.parchment` and `palettes.dark`, and each of them composes with
+/// each theme:
+///
+/// ```typ
+/// #show: presentation.with(theme: themes.lesson, palette: palettes.dark)
+/// ```
+///
+/// Two colors of a theme are not palette entries: `title-fill` and
+/// `rule-fill`. All five bundled themes let them follow, either as a function
+/// of the palette or as `none`, which means the accent and follows with it. A
+/// theme of your own that names a fixed color there keeps it under every
+/// palette, which is deliberate.
+///
+/// Both changed type with this: reading `themes.X.title-fill` used to give a
+/// color and now gives a function, and `rule-fill` gives `none` where it gave
+/// the accent. Writing them, `themes.X + (title-fill: red)`, is unchanged.
+///
 /// The PDF is a handout: one page per slide, every tracked element in its
 /// final state. What belongs only to the motion, the notes, the slide transitions,
 /// the bridge jobs, are state updates without output and fall away by themselves.
@@ -229,6 +251,7 @@
   date: none,
   assets: "inline",
   theme: themes.default,
+  palette: (:),
   transition: "slide",
   transition-duration: 420,
   duration: 520,
@@ -261,9 +284,35 @@
     } else { rest }
   }
   let all = all.map(s => if s.body == none { s } else {
-    s + (body: apply-pauses(s.body))
+    // The marker is looked for in the body as it was written, before the
+    // pauses cut it into runs: after that, a marker standing behind a pause
+    // sits inside an `anim` wrapper and the walk would miss it. The title is
+    // searched too, because in heading notation `== A slide #invert` is the
+    // place the marker naturally lands, and it went unseen there.
+    s + (invert: s.at("invert", default: false)
+                 or hat-invert(s.body) or hat-invert(s.title),
+         body: apply-pauses(s.body))
   })
   let total = all.filter(s => s.kind == "slide").len()
+
+  // The theme with the palette laid over it, once for the deck and once
+  // turned around. Both are worked out here rather than per slide: they are
+  // the same two dictionaries on every slide, and the inverted one is only
+  // ever reached for by a slide that asked for it.
+  //
+  // Both are built from the theme as it came in, not the inverted one from
+  // the merged one. `mit-palette` resolves `title-fill` and `rule-fill` into
+  // colors, so a theme that has already been through it no longer carries the
+  // functions the inversion has to ask again.
+  let palette = palette-pruefen(palette)
+  let thema-hell = mit-palette(theme, palette)
+  let thema-dunkel = mit-palette(theme, palette, invert: true)
+  let thema(s) = if s.at("invert", default: false) { thema-dunkel } else { thema-hell }
+  // Whether any slide inverts at all. A deck without one writes the theme
+  // into its state exactly once, as before; only a deck that inverts pays for
+  // an update per slide, and there it is needed, since a `card` reads its
+  // tints out of that state and has to see the slide it stands on.
+  let wechselt = all.any(s => s.at("invert", default: false))
 
   // Everything the deck knows about itself, one entry per slide, counted here
   // and nowhere else. All three outputs read from this list, and so does a
@@ -306,13 +355,14 @@
     let per = if handout == true { 2 } else { handout }
     assert(type(per) == int and per >= 1 and per <= 6,
            message: "typstage: handout takes true or 1 to 6 slides per page")
-    theme-state.update(theme)
+    theme-state.update(thema-hell)
     html-output.update(false)
-    handout-body(all, facts, style, geo, theme, per, overflow: overflow)
+    handout-body(all, facts, style, geo, thema-hell, per,
+                 thema: if wechselt { thema } else { none }, overflow: overflow)
     ueberlauf-bericht(overflow)
   } else if target() != "html" {
     set page(width: geo.width, height: geo.height, margin: 0pt)
-    theme-state.update(theme)
+    theme-state.update(thema-hell)
     // Said out loud, not left to the default. `bundle()` writes several
     // documents from one compilation, and a state carries on from one into the
     // next: without this the slide deck and the handout of a bundle were still
@@ -334,13 +384,14 @@
                  // its last value standing.
                  + step-here.update(())
                  + sprite-number.update(none)
-                 + slide-body(s, style, geo, theme, overflow: overflow))
+                 + (if wechselt { theme-state.update(thema(s)) } else { none })
+                 + slide-body(s, style, geo, thema(s), overflow: overflow))
     }
     pages.join(pagebreak(weak: true))
     ueberlauf-bericht(overflow)
   } else {
     html-output.update(true)
-    theme-state.update(theme)
+    theme-state.update(thema-hell)
     morph-index.update(())
     let parts = ()
     let chrome-teile = ()
@@ -369,7 +420,7 @@
           deck-info.update(hier)
           step-here.update(())
           sprite-number.update(none)
-          html.frame(slide-chrome(geo, theme))
+          html.frame(slide-chrome(geo, thema(s)))
         } else { [] }))
       parts.push({
         slide-counter.step()
@@ -382,12 +433,16 @@
         bridge-jobs.update(())
         note-state.update(s.note)
         transition-state.update(s.at("transition", default: none))
+        // Only a deck that inverts somewhere writes this per slide. A `card`
+        // and a `callout` read their tints out of this state and would
+        // otherwise light the slide they stand on as if it were not inverted.
+        if wechselt { theme-state.update(thema(s)) }
         // Order is everything here: the frame has to come BEFORE the `context`
         // that reads the sprite list. Otherwise nothing that only registers
         // while the frame is laid out would be entered any more.
         html.elem("section", attrs: (class: "ts-slide"), {
           html.elem("div", attrs: (class: "ts-bg"),
-                    html.frame(slide-body(s, style, geo, theme, chrome: false,
+                    html.frame(slide-body(s, style, geo, thema(s), chrome: false,
                                           overflow: overflow)))
           // Second chrome, only for the print view (key `p`). There each
           // slide stands on its own page, there is no transition. And the
@@ -398,7 +453,7 @@
             html.elem("div", attrs: (class: "ts-chromep"), {
               step-here.update(())
               sprite-number.update(none)
-              html.frame(slide-chrome(geo, theme))
+              html.frame(slide-chrome(geo, thema(s)))
             })
           }
           context {

--- a/src/present.typ
+++ b/src/present.typ
@@ -479,10 +479,17 @@
             // range is closed -- `anim` insists on that -- but a closed range
             // can still end with the slide, and then there is no step left to
             // be dim on.
+            // `hier.nr`, nicht `here`: die Marke am Folienende trägt `nr`,
+            // und das zählt jeden Eintrag mit, auch Titel- und
+            // Abschnittsfolien. `here` ist die Nummer unter den Inhaltsfolien
+            // allein. Sobald ein Deck eine Titelfolie hat, laufen die beiden
+            // auseinander, und der Test unten befragte die falsche Folie nach
+            // ihrer Schrittzahl -- gemessen wurde ein gültiges Deck
+            // abgewiesen, sobald man ihm einen Titel gab.
             let meine-dims = sprites.get()
               .filter(sp => sp.extra.at("after", default: none) == "dimmed"
                             and not sp.at("dim-freiwillig", default: false))
-              .map(sp => (slide: here, bis: max-step(sp.at)))
+              .map(sp => (slide: hier.nr, nummer: here, bis: max-step(sp.at)))
             dim-index.update(a => a + meine-dims)
             html.elem("script", attrs: (class: "ts-bridge", type: "application/json"),
                       json.encode(bridge-jobs.get()))
@@ -518,7 +525,7 @@
           calc.max(1, step-cursor.at(ende.location()).first())
         }
         assert(d.bis < gesamt, message:
-          "typstage: anim(after: \"dimmed\") on slide " + str(d.slide)
+          "typstage: anim(after: \"dimmed\") on slide " + str(d.nummer)
           + " has a range that ends with the slide: it runs to step "
           + str(d.bis) + " and the slide has " + str(gesamt)
           + ". There is no step left for the element to be dim on, so it "

--- a/src/present.typ
+++ b/src/present.typ
@@ -232,6 +232,40 @@
   })
   let total = all.filter(s => s.kind == "slide").len()
 
+  // Everything the deck knows about itself, one entry per slide, counted here
+  // and nowhere else. All three outputs read from this list, and so does a
+  // deck's own `info()`; that there is exactly one list is the whole reason a
+  // hand-built footer cannot disagree with the built-in one.
+  //
+  // `nr` counts every slide, title and section slides included, and stays out
+  // of the public dictionary: it is only the key under which a slide files its
+  // step count. `slide.number` deliberately counts differently.
+  let daten = {
+    let kopf = all.find(s => s.kind == "title")
+    if kopf != none {
+      (title: kopf.title, subtitle: kopf.subtitle,
+       author: kopf.author, date: kopf.date)
+    } else {
+      (title: title, subtitle: subtitle, author: author, date: date)
+    }
+  }
+  let sect-total = all.filter(s => s.kind == "section").len()
+  let facts = ()
+  let gezaehlt = 0
+  let kapitel = 0
+  let kapitel-titel = none
+  for (i, s) in all.enumerate() {
+    if s.kind == "slide" { gezaehlt += 1 }
+    if s.kind == "section" { kapitel += 1; kapitel-titel = s.title }
+    facts.push((
+      nr: i + 1,
+      data: daten + (
+        slide: (number: gezaehlt, total: total, numbered: s.kind == "slide"),
+        section: (number: kapitel, total: sect-total, title: kapitel-titel),
+      ),
+    ))
+  }
+
   // The branch has to enclose the *whole* build, not just the output: in
   // paged mode the module `html` does not even exist, so an `html.elem` in the
   // dead branch would already be an error.
@@ -240,50 +274,75 @@
     assert(type(per) == int and per >= 1 and per <= 6,
            message: "typstage: handout takes true or 1 to 6 slides per page")
     theme-state.update(theme)
-    handout-body(all, total, style, geo, theme, per)
+    html-output.update(false)
+    handout-body(all, facts, style, geo, theme, per)
   } else if target() != "html" {
     set page(width: geo.width, height: geo.height, margin: 0pt)
     theme-state.update(theme)
-    let n = 0
+    // Said out loud, not left to the default. `bundle()` writes several
+    // documents from one compilation, and a state carries on from one into the
+    // next: without this the slide deck and the handout of a bundle were still
+    // being built as if they were the browser's, and every tracked element
+    // stayed in `hide()` and was missing from the PDF. Measured on a bundle
+    // with an `anim` and an `alternatives`, and the same for the handout above.
+    html-output.update(false)
     let pages = ()
-    // Which section is currently running. The header in book style shows it
-    // on the right, the way a schoolbook shows the chapter. It is counted here
-    // in the loop rather than via a state: the order is fixed either way, so
-    // this stays one line instead of one more state.
-    let sect = none
-    for s in all {
-      if s.kind == "slide" { n += 1 }
-      if s.kind == "section" { sect = s.title }
+    for (i, s) in all.enumerate() {
       pages.push(slide-counter.step()
-                 + slide-body(s, n, total, style, geo, theme, sect: sect))
+                 + deck-info.update(facts.at(i))
+                 // Nothing is revealed on paper, but the cursor counts here
+                 // too, so that `info().step.total` reports the same number in
+                 // both outputs. It has to start over on every slide.
+                 + step-cursor.update(0)
+                 // Nothing on a page sits inside a reveal, so the step being
+                 // laid out is the first one. Said out loud for the sake of
+                 // `bundle()`, where the browser document ran first and left
+                 // its last value standing.
+                 + step-here.update(())
+                 + sprite-number.update(none)
+                 + slide-body(s, style, geo, theme))
     }
     pages.join(pagebreak(weak: true))
   } else {
     html-output.update(true)
     theme-state.update(theme)
     morph-index.update(())
-    let n = 0
     let parts = ()
     let chrome-teile = ()
-    let sect = none
-    for s in all {
-      if s.kind == "slide" { n += 1 }
-      if s.kind == "section" { sect = s.title }
-      let here = n
-      let hier-sect = sect
+    for (i, s) in all.enumerate() {
+      let hier = facts.at(i)
+      let here = hier.data.slide.number
       // Footer and progress come as their own layer above the stage, not
       // into the slide. Otherwise they would leave along with it on
       // transition, while the next one's comes in: two bars would be seen
       // crossing instead of one growing. Title and section slides carry
       // none; their entry stays empty so the count matches the slides.
+      //
+      // This layer is written out at the *end* of the document, long after
+      // the slides. What the chrome reads therefore has to be put back in
+      // front of each of its frames, or all of them would draw the numbers of
+      // the last slide.
       chrome-teile.push(html.elem("div", attrs: (class: "ts-chrome"),
         if s.kind == "slide" {
-          html.frame(slide-chrome(here, total, geo, theme, sect: hier-sect))
+          // The step is said out loud as well, even though the chrome prints
+          // no step: chrome stands inside no reveal, so its step is the first
+          // one. Without it the reading would hang off whatever the last
+          // sprite of the last slide left standing, and that lengthens the
+          // chain of things Typst has to settle for no gain. Measured on a
+          // `bundle()`, where the chain then ran past five attempts and Typst
+          // said "document did not converge".
+          deck-info.update(hier)
+          step-here.update(())
+          sprite-number.update(none)
+          html.frame(slide-chrome(geo, theme))
         } else { [] }))
       parts.push({
         slide-counter.step()
+        deck-info.update(hier)
         element-counter.update(0)
         step-cursor.update(0)
+        step-here.update(())
+        sprite-number.update(none)
         sprites.update(())
         bridge-jobs.update(())
         note-state.update(s.note)
@@ -293,17 +352,18 @@
         // while the frame is laid out would be entered any more.
         html.elem("section", attrs: (class: "ts-slide"), {
           html.elem("div", attrs: (class: "ts-bg"),
-                    html.frame(slide-body(s, here, total, style, geo, theme,
-                                         chrome: false, sect: hier-sect)))
+                    html.frame(slide-body(s, style, geo, theme, chrome: false)))
           // Second chrome, only for the print view (key `p`). There each
           // slide stands on its own page, there is no transition. And the
           // layer above the stage cannot travel along there, because the
           // slides stand one below another. On screen this one stays
           // hidden.
           if s.kind == "slide" {
-            html.elem("div", attrs: (class: "ts-chromep"),
-                      html.frame(slide-chrome(here, total, geo, theme,
-                                              sect: hier-sect)))
+            html.elem("div", attrs: (class: "ts-chromep"), {
+              step-here.update(())
+              sprite-number.update(none)
+              html.frame(slide-chrome(geo, theme))
+            })
           }
           context {
             let tr = transition-state.get()

--- a/src/render.typ
+++ b/src/render.typ
@@ -1,6 +1,7 @@
 // Turning tracked elements into HTML.
 
 #import "config.typ": *
+#import "internal.typ": sprite-number
 #import "theme.typ": with-style
 
 /// One sprite: the element as its own small frame, plus everything the runtime
@@ -36,6 +37,7 @@
     html.elem("div", attrs: attrs, html.elem("iframe", attrs: a, []))
   } else if s.kind == "flipbook" {
     html.elem("div", attrs: attrs + ("data-frames": str(s.raw-frames.len())),
+      sprite-number.update(n) +
       s.raw-frames.map(f => html.elem("div", attrs: (class: "ts-frame"),
         html.frame(block(width: s.width, height: s.height,
                          template(with-style(s, block(
@@ -50,6 +52,11 @@
       // again
       // of an element that vanished into its parent's `hide()`.
       counter("typstage-n").update(n)
+      // And which element this is, so that a body printing
+      // `info().step.number` reads its own step here and not the slide's last
+      // one. Only the number travels; the step itself is looked up from
+      // `sprites`, for the reason given at `sprite-number`.
+      sprite-number.update(n)
       // The measured size on the outside, since that decides the frame, and
       // the region from back then on the inside. A relative measure in the body
       // therefore resolves exactly once, and against the same reference as in

--- a/src/slides.typ
+++ b/src/slides.typ
@@ -1,7 +1,7 @@
 // Slides, sections and what belongs to a single slide.
 
-#import "internal.typ": (deck-info, html-output, note-state, step-cursor,
-                        step-jetzt, transition-state)
+#import "internal.typ": (deck-info, html-output, note-state, notiz-pruefen,
+                        step-cursor, step-jetzt, transition-state)
 
 /// A regular slide.
 ///
@@ -20,6 +20,9 @@
     kopf = teile.at(0)
     rumpf = teile.at(1)
   }
+  // Same rule as for `speaker-note`, because this is the other way of writing
+  // the same thing. `none` stays legal: that is a slide without a note.
+  if note != none { notiz-pruefen(note) }
   (kind: "slide", title: kopf, note: note, transition: transition, body: rumpf)
 }
 
@@ -123,4 +126,11 @@
 }
 
 /// A note for the presenter view (key `s`).
-#let speaker-note(body) = note-state.update(body)
+///
+/// The note has to carry text: the presenter view transports it as a string,
+/// so a note made purely of layout would arrive nowhere. That is refused with
+/// a message rather than silently dropped.
+#let speaker-note(body) = {
+  notiz-pruefen(body)
+  note-state.update(body)
+}

--- a/src/slides.typ
+++ b/src/slides.typ
@@ -1,6 +1,7 @@
 // Slides, sections and what belongs to a single slide.
 
-#import "internal.typ": note-state, transition-state
+#import "internal.typ": (deck-info, html-output, note-state, step-cursor,
+                        step-jetzt, transition-state)
 
 /// A regular slide.
 ///
@@ -53,6 +54,73 @@
 /// Backwards each one runs as a true reversal. If a morph meets the slide it
 /// cross-fades regardless: the movement is then carried by the morph.
 #let transition(kind, ..spec) = transition-state.update((kind: kind) + spec.named())
+
+/// What the deck knows about itself, read from inside a slide.
+///
+/// ```typ
+/// #context {
+///   let deck = info()
+///   [#deck.section.title #h(1fr) #deck.slide.number/#deck.slide.total]
+/// }
+/// ```
+///
+/// It is the same reading the built-in chrome does. Every number the package
+/// prints on a slide, the footer, the fraction, the length of the progress bar
+/// and the running header, comes out of this function and out of no second
+/// count, so a hand-built footer and the built-in one cannot disagree.
+///
+/// What comes back, as a dictionary:
+///
+/// - `title`, `subtitle`, `author`, `date`: the deck's own particulars, as
+///   `presentation` or a `title-slide` received them.
+/// - `slide.number`, `slide.total`: this slide and how many there are.
+///   Counted the way the footer counts, so title and section slides are not
+///   in it.
+/// - `slide.numbered`: whether this slide is one of the counted ones. It is
+///   `false` on a title slide and on a section slide, and `number` then holds
+///   the last slide counted before it, 0 on a cover that opens the deck. A
+///   footer can therefore leave its counter slot clear instead of printing a
+///   zero into it.
+/// - `step.number`, `step.total`: this deck counts in steps as well as in
+///   slides, which no footer can guess at. `number` is the step the calling
+///   content itself stands on: 1 in the body of a slide, and inside an
+///   `anim`, a `stagger` or an `alternatives` the step of that reveal, its
+///   first one where it covers several. On paper a slide is one page in its
+///   final state, so `number` is `total` there.
+/// - `section.number`, `section.total`, `section.title`: which section the
+///   slide belongs to, how many the deck has, and its title. Before the first
+///   `=` heading, `number` is `0` and `title` is `none`.
+///
+/// Only in a context. *Before* any presentation has run there is nothing to
+/// read and this stops with a message rather than handing out zeros. *After*
+/// one it does not: whoever passes the slides as arguments and writes an
+/// `info()` below the call still gets the last slide's numbers. Clearing the
+/// deck's own record at the end would close that, and it was measured: a slide
+/// carrying one reveal beside a `tiles` went from no layout warning to three
+/// "did not converge" ones. A corner nobody stands in is not worth that, and in
+/// the show-rule notation nothing comes after the deck anyway.
+#let info() = {
+  let stand = deck-info.get()
+  assert(stand != none, message:
+    "typstage: info() reads what the deck knows about itself and therefore "
+    + "works only inside a presentation.")
+  // A footer stands inside the slide whose step count it wants, and that count
+  // is only settled once the slide has been laid out. So the count is fetched
+  // from the far end: `slide-body` leaves a mark there carrying the slide's
+  // number, and the cursor is read at that mark. The same forward reference as
+  // "page 3 of 12", and read straight off the counter rather than passed
+  // through a state, which would cost one layout run too many.
+  let ende = query(<typstage-slide-end>).find(e => e.value == stand.nr)
+  let gesamt = if ende == none { 1 } else {
+    calc.max(1, step-cursor.at(ende.location()).first())
+  }
+  stand.data + (step: (
+    // Paged output has no current step. Every page shows the slide in its
+    // final state, everything at once, so the step shown is the last one.
+    number: if html-output.get() { step-jetzt() } else { gesamt },
+    total: gesamt,
+  ))
+}
 
 /// A note for the presenter view (key `s`).
 #let speaker-note(body) = note-state.update(body)

--- a/src/slides.typ
+++ b/src/slides.typ
@@ -7,7 +7,18 @@
 ///
 /// `title: none`, or a bare `==` in heading form, leaves out the title bar;
 /// the body then gets the whole area.
-#let slide(title: none, note: none, transition: none, ..rest) = {
+///
+/// `invert: true` sets this one slide in the palette turned around, for the
+/// slide that carries a single number. The ground becomes the palette's text
+/// color and the text becomes its ground; `muted`, `border` and `surface` are
+/// mixed from those two; `strong` and `accent` carry over unchanged. The
+/// chrome follows, so the running header, the footer and the progress bar are
+/// set in the same colors as the slide under them.
+///
+/// Only a regular slide inverts. A title slide and a section slide are whole
+/// pictures the theme draws itself, and three of the five bundled themes build
+/// them from colors an inversion would not reach; neither takes the argument.
+#let slide(title: none, note: none, transition: none, invert: false, ..rest) = {
   // So that all three notations work: `slide[body]` (without a title),
   // `slide([title])[body]` and `slide(none)[body]`. A single piece is the
   // body, two are title and body.
@@ -23,8 +34,30 @@
   // Same rule as for `speaker-note`, because this is the other way of writing
   // the same thing. `none` stays legal: that is a slide without a note.
   if note != none { notiz-pruefen(note) }
-  (kind: "slide", title: kopf, note: note, transition: transition, body: rumpf)
+  (kind: "slide", title: kopf, note: note, transition: transition,
+   invert: invert, body: rumpf)
 }
+
+/// The same thing in the heading notation, written into the slide body.
+///
+/// ```typ
+/// == Reached in 2026
+/// #invert
+/// #statement[74 %]
+/// ```
+///
+/// A marker, like `#pause`, because a heading carries no arguments. Unlike
+/// `#pause` it is only looked for, never split on, so the walk goes all the
+/// way down: it is found in a `block`, an `align`, a table cell, a grid,
+/// however deeply nested, in the heading itself, and behind `#set` and
+/// `#show`. It is not found where the content is handed to a closure -- in
+/// `context`, `fit`, `anim`, `card` or `alternatives` -- and there nothing
+/// happens and nothing is said. Measured, those five are the whole of it;
+/// `slide(invert: true)` is the form that never depends on the walk.
+///
+/// It prints nothing, so it may stand anywhere in the body; it inverts the
+/// whole slide either way, not the part after it.
+#let invert = metadata("typstage-invert")
 
 /// A section slide.
 #let section(title, transition: none) = (

--- a/src/theme.typ
+++ b/src/theme.typ
@@ -8,9 +8,25 @@
 // said by the theme (see `themes.typ`). Every number below is either a
 // measure from the theme or a point value on the default canvas, scaled
 // along with `k`.
+//
+// Every shape drawn here carries a label, so a deck can restyle it with an
+// ordinary `show` rule instead of forking the theme. One rule of thumb keeps
+// those labels usable, and it was learned the hard way from Typst's
+// precedence: a label goes *inside* the `text(..)` or the `set rect(..)` that
+// gives the shape its default look, never around it. An explicit constructor
+// argument beats a `set` rule, so `[#text(fill: x)[..] <l>]` could never be
+// recolored, while `text(fill: x, [#.. <l>])` can. Measured on four minimal
+// cases, and it holds for `rect` and `block` the same way.
+//
+// Nesting two labels is fine. `[#gruppe <aussen>]` around a group that
+// already carries a label attaches to the enclosing group, not to the same
+// element, so both rules run and the inner one wins wherever they set the
+// same property. Only two labels on the *same* element collide, and Typst
+// says so: "content labelled multiple times", and the last one is used.
 
 #import "config.typ": *
-#import "internal.typ": note-state, plain-text, slide-counter
+#import "internal.typ": (note-state, plain-text, slide-counter,
+                        umgebungs-block)
 #import "themes.typ": font-args
 
 /// The body of one slide, background included.
@@ -43,22 +59,32 @@
     // the footer, otherwise the orientation it is meant to give would
     // travel out with the slide.
     if t.header == "run" {
-      let zeile = text(size: 11.5pt * k, fill: t.muted, {
+      let zeile = text(size: 11.5pt * k, fill: t.muted, [#{
         str(n)
         if sect != none [ #h(1fr) #sect ]
-      })
+      } <ts-slide-header-text>])
       place(top + left, dx: m.left, dy: m.top * 0.62,
             block(width: inner, zeile))
-      place(top + left, dx: m.left, dy: m.top * 0.62 + 17pt * k,
-            rect(width: inner, height: 0.9pt * k, fill: t.rule-fill, stroke: none))
+      place(top + left, dx: m.left, dy: m.top * 0.62 + 17pt * k, {
+        set rect(fill: t.rule-fill, stroke: none)
+        [#rect(width: inner, height: 0.9pt * k) <ts-slide-header-rule>]
+      })
     }
     // Footer: the number, optionally with the total, and a hairline above
     // it.
     if t.footer-rule > 0pt {
-      place(bottom + left, dx: m.left, dy: -(t.foot-gap + 6pt) * k,
-            rect(width: inner, height: t.footer-rule * k, fill: t.border, stroke: none))
+      place(bottom + left, dx: m.left, dy: -(t.foot-gap + 6pt) * k, {
+        set rect(fill: t.border, stroke: none)
+        [#rect(width: inner, height: t.footer-rule * k) <ts-slide-footer-rule>]
+      })
     }
-    let zahl = if t.footer == "fraction" { str(n) + " / " + str(total) } else { str(n) }
+    // Two labels, one inside the other: the footer line is what a deck
+    // restyles as a whole, the number is the part it may want smaller or in
+    // another color on its own. Both attach, because the outer one lands on
+    // the enclosing group rather than on the same element.
+    let zahl = [#[#{
+      if t.footer == "fraction" { str(n) + " / " + str(total) } else { str(n) }
+    } <ts-slide-number>] <ts-slide-footer>]
     if t.footer == "center" {
       place(bottom + center, dy: -13pt * k, text(size: 12pt * k, fill: t.muted, zahl))
     } else if t.footer != "none" {
@@ -69,11 +95,15 @@
     // travels along its track: even at seventy slides that still shows
     // where you are, while the bar there only grows longer very slowly.
     if t.progress == "bar" {
-      place(bottom + left,
-            rect(width: 100% * n / total, height: 2.5pt * k, fill: t.accent, stroke: none))
+      place(bottom + left, {
+        set rect(fill: t.accent, stroke: none)
+        [#rect(width: 100% * n / total, height: 2.5pt * k) <ts-slide-progress>]
+      })
     } else if t.progress == "top" {
-      place(top + left,
-            rect(width: 100% * n / total, height: 2.5pt * k, fill: t.accent, stroke: none))
+      place(top + left, {
+        set rect(fill: t.accent, stroke: none)
+        [#rect(width: 100% * n / total, height: 2.5pt * k) <ts-slide-progress>]
+      })
     } else if t.progress == "tick" {
       // The marker must be at least as wide as its own step, otherwise it
       // jumps over gaps instead of traveling. At nine slides the step was
@@ -87,10 +117,14 @@
       // marker was already advanced a bit on slide one and never reached
       // the end.
       let schritte = calc.max(1, total - 1)
-      place(bottom + left,
-            rect(width: 100%, height: 3pt * k, fill: t.accent.lighten(78%), stroke: none))
-      place(bottom + left, dx: (geo.width - breite) * (n - 1) / schritte,
-            rect(width: breite, height: 3pt * k, fill: t.accent, stroke: none))
+      place(bottom + left, {
+        set rect(fill: t.accent.lighten(78%), stroke: none)
+        [#rect(width: 100%, height: 3pt * k) <ts-slide-progress-track>]
+      })
+      place(bottom + left, dx: (geo.width - breite) * (n - 1) / schritte, {
+        set rect(fill: t.accent, stroke: none)
+        [#rect(width: breite, height: 3pt * k) <ts-slide-progress>]
+      })
     }
   })
 }
@@ -110,6 +144,10 @@
   // that sits further inside, and whatever is set there overrides the
   // theme.
   set text(..font-args(t.font), size: t.size * k, fill: t.ink)
+  // No label around these two: their parts carry their own, and a collective
+  // `ts-title-slide` would have read like `ts-slide-title` with the words
+  // swapped. A theme bringing its own title slide function draws none of
+  // them, and nothing warns about that.
   if s.kind == "title" {
     (t.title-slide)(t, s, geo)
   } else if s.kind == "section" {
@@ -136,11 +174,17 @@
     }
     let titel-text = text(
       ..font-args(t.title-font), size: t.title-size * k, weight: t.weight,
-      fill: t.title-fill, tracking: t.tracking * k, s.title,
+      fill: t.title-fill, tracking: t.tracking * k, [#s.title <ts-slide-title>],
     )
-    rect(width: 100%, height: 100%, fill: t.paper, stroke: none)
+    {
+      set rect(fill: t.paper, stroke: none)
+      [#rect(width: 100%, height: 100%) <ts-slide-ground>]
+    }
     if titel and t.header == "band" {
-      place(top + left, rect(width: 100%, height: bar, fill: t.strong, stroke: none))
+      place(top + left, {
+        set rect(fill: t.strong, stroke: none)
+        [#rect(width: 100%, height: bar) <ts-slide-header-band>]
+      })
       place(top + left, dx: m.left,
         block(width: inner, height: bar, align(left + horizon, titel-text)))
     } else if titel {
@@ -151,9 +195,10 @@
       place(top + left, dx: m.left, dy: m.top + lauf, block(width: inner, {
         block(above: 0pt, below: 0pt, titel-text)
         if t.rule-size > 0pt {
-          block(above: t.title-size * 0.34 * k, below: 0pt,
-            rect(width: 100%, height: t.rule-size * k, fill: t.rule-fill,
-                 stroke: none))
+          block(above: t.title-size * 0.34 * k, below: 0pt, {
+            set rect(fill: t.rule-fill, stroke: none)
+            [#rect(width: 100%, height: t.rule-size * k) <ts-slide-title-rule>]
+          })
         }
       }))
     }
@@ -209,13 +254,14 @@
 
   let lines(height) = {
     let count = calc.max(2, int(height.pt() / 17))
-    stack(dir: ttb, spacing: 17pt,
-          ..range(count).map(_ => line(length: 100%, stroke: 0.4pt + luma(84%))))
+    set line(stroke: 0.4pt + luma(84%))
+    [#stack(dir: ttb, spacing: 17pt,
+            ..range(count).map(_ => line(length: 100%))) <ts-handout-lines>]
   }
   let room-for-notes(height) = context {
     let note = note-state.get()
     if note != none and plain-text(note).trim() != "" {
-      text(size: 9pt, fill: luma(35%), note)
+      text(size: 9pt, fill: luma(35%), [#note <ts-handout-note>])
     } else { lines(height) }
   }
 
@@ -248,11 +294,19 @@
       calc.min(room.width, share * (geo.width / geo.height))
     }
     let h = w * (geo.height / geo.width)
-    let framed(item) = block(
-      width: w, height: h, clip: true, radius: 2pt,
-      stroke: 0.5pt + luma(72%),
-      scale(w / geo.width * 100%, origin: top + left,
-            slide-body(item.slide, item.number, total, style, geo, t)))
+    // The frame's own look travels through a `set` rule, so a label rule can
+    // reach it; the shrunk slide inside gets the surrounding style put back,
+    // or it would inherit the frame's stroke and radius and draw a second
+    // border around itself.
+    let framed(item) = context {
+      let aussen = umgebungs-block()
+      set block(radius: 2pt, stroke: 0.5pt + luma(72%))
+      [#block(width: w, height: h, clip: true, {
+        set block(fill: aussen.fill, stroke: aussen.stroke, radius: aussen.radius)
+        scale(w / geo.width * 100%, origin: top + left,
+              slide-body(item.slide, item.number, total, style, geo, t))
+      }) <ts-handout-frame>]
+    }
 
     let rows = sheet.map(item => {
       // Counted here too, not only in the other two branches: a companion

--- a/src/theme.typ
+++ b/src/theme.typ
@@ -25,8 +25,9 @@
 // says so: "content labelled multiple times", and the last one is used.
 
 #import "config.typ": *
-#import "internal.typ": (deck-info, note-state, plain-text, slide-counter,
-                        sprite-number, step-cursor, step-here, umgebungs-block)
+#import "internal.typ": (deck-info, html-output, note-state, plain-text,
+                        slide-counter, sprite-number, step-cursor, step-here,
+                        ueberlauf-pruefen, umgebungs-block)
 #import "slides.typ": info
 #import "themes.typ": font-args
 
@@ -137,7 +138,7 @@
   })
 }
 
-#let slide-body(s, style, geo, t, chrome: true) = block(
+#let slide-body(s, style, geo, t, chrome: true, overflow: "none") = block(
   width: geo.width, height: geo.height,
 {
   // A mark at the end of the slide, so that a footer inside it can ask the
@@ -243,10 +244,24 @@
     // the slide.
     if chrome { place(top + left, slide-chrome(geo, t)) }
 
+    // The room the deck's content gets, and the one measure the overflow
+    // check asks against. Everything else the slide shows, the band, the
+    // title, the footer, the progress, is drawn beside this block with
+    // `place` and takes nothing away from it.
+    let raum = geo.height - kopf - (t.head-gap + t.foot-gap) * k
     place(top + left, dx: m.left, dy: kopf + t.head-gap * k,
-      block(width: inner,
-            height: geo.height - kopf - (t.head-gap + t.foot-gap) * k,
-            style(s.body)))
+      block(width: inner, height: raum, style(s.body)))
+    // `place`, like the mark above: the block is already slide-high and full,
+    // and the check must not take a single point from the body it measures.
+    // Only for slides. A title or a section slide is drawn by the theme with
+    // `place` and has no body block to overrun.
+    if overflow != "none" {
+      place(top + left, context ueberlauf-pruefen(
+        deck-info.get().data.slide.number, style(s.body), inner, raum,
+        // The step is read off the slide's own reveals, and on paper there
+        // are none: every step stands on the page at once.
+        schritte: html-output.get()))
+    }
   }
   // Last, because only here has the cursor seen every reveal of the slide.
   schritt-summe
@@ -275,7 +290,7 @@
 /// Where a slide has a speaker note it stands in that room; where it has none,
 /// ruled lines take its place. Both are the same thing really: the space is
 /// for whatever is not on the slide itself.
-#let handout-body(all, facts, style, geo, t, per-page) = {
+#let handout-body(all, facts, style, geo, t, per-page, overflow: "none") = {
   set page(paper: "a4", margin: (x: 1.5cm, y: 1.4cm))
   set text(size: 10pt, fill: t.strong)
   let gap = 14pt
@@ -334,7 +349,7 @@
       [#block(width: w, height: h, clip: true, {
         set block(fill: aussen.fill, stroke: aussen.stroke, radius: aussen.radius)
         scale(w / geo.width * 100%, origin: top + left,
-              slide-body(item.slide, style, geo, t))
+              slide-body(item.slide, style, geo, t, overflow: overflow))
       }) <ts-handout-frame>]
     }
 

--- a/src/theme.typ
+++ b/src/theme.typ
@@ -25,8 +25,9 @@
 // says so: "content labelled multiple times", and the last one is used.
 
 #import "config.typ": *
-#import "internal.typ": (note-state, plain-text, slide-counter,
-                        umgebungs-block)
+#import "internal.typ": (deck-info, note-state, plain-text, slide-counter,
+                        sprite-number, step-cursor, step-here, umgebungs-block)
+#import "slides.typ": info
 #import "themes.typ": font-args
 
 /// The body of one slide, background included.
@@ -48,7 +49,14 @@
 /// `slide-chrome` draws it, `slide-body` has to place the title below it.
 #let lauf-hoehe(t, k) = if t.header == "run" { 27pt * k } else { 0pt }
 
-#let slide-chrome(n, total, geo, t, sect: none) = {
+#let slide-chrome(geo, t) = context {
+  // Every number below comes out of `info()`, and that is the point of the
+  // detour: the deck may call the same function, so a hand-built footer and
+  // this one read the same dictionary and cannot disagree.
+  let d = info()
+  let n = d.slide.number
+  let total = d.slide.total
+  let sect = d.section.title
   let k = geo.scale
   let m = margins(geo)
   let inner = geo.width - m.left - m.right
@@ -129,9 +137,32 @@
   })
 }
 
-#let slide-body(s, n, total, style, geo, t, chrome: true, sect: none) = block(
+#let slide-body(s, style, geo, t, chrome: true) = block(
   width: geo.width, height: geo.height,
 {
+  // A mark at the end of the slide, so that a footer inside it can ask the
+  // step cursor how far it got. The mark carries the slide's running number,
+  // which is what `info()` matches on.
+  //
+  // The reading is taken off the *counter* at this mark rather than filed into
+  // a state here and read back from there, and that is not a matter of taste.
+  // A cursor-reading group such as `stagger` or `tiles` builds its step
+  // numbers out of what it read, so the cursor already sits at the end of a
+  // chain several layout runs long; writing that value into a state puts one
+  // more run on top, and Typst allows five. Measured on a slide with two such
+  // groups: with the state, "did not converge" in both outputs; reading the
+  // counter at this mark, the same slide behaves exactly as it did before
+  // `info()` existed.
+  //
+  // `place`, so it takes no room in the flow. The block is exactly slide-high
+  // and already full; anything joined into it after the ground rect would sit
+  // in a flow that has nothing left to give.
+  //
+  // Machinery, not a shape, so it is named like the bridge's marker and not
+  // like the `ts-` labels a deck restyles.
+  let schritt-summe = place(top + left, context {
+    [#metadata(deck-info.get().nr) <typstage-slide-end>]
+  })
   // Everything below is measured on the default canvas and scaled with it, so
   // a smaller or wider slide keeps its proportions.
   let k = geo.scale
@@ -210,13 +241,15 @@
     // full slide height. In the flow it would push everything below it
     // away, and its `bottom` anchors would refer to itself instead of to
     // the slide.
-    if chrome { place(top + left, slide-chrome(n, total, geo, t, sect: sect)) }
+    if chrome { place(top + left, slide-chrome(geo, t)) }
 
     place(top + left, dx: m.left, dy: kopf + t.head-gap * k,
       block(width: inner,
             height: geo.height - kopf - (t.head-gap + t.foot-gap) * k,
             style(s.body)))
   }
+  // Last, because only here has the cursor seen every reveal of the slide.
+  schritt-summe
 })
 
 /// A hook that wraps a document template around every body and every sprite.
@@ -242,7 +275,7 @@
 /// Where a slide has a speaker note it stands in that room; where it has none,
 /// ruled lines take its place. Both are the same thing really: the space is
 /// for whatever is not on the slide itself.
-#let handout-body(all, total, style, geo, t, per-page) = {
+#let handout-body(all, facts, style, geo, t, per-page) = {
   set page(paper: "a4", margin: (x: 1.5cm, y: 1.4cm))
   set text(size: 10pt, fill: t.strong)
   let gap = 14pt
@@ -265,13 +298,10 @@
     } else { lines(height) }
   }
 
-  // Numbered first, so the count keeps running across the page breaks.
-  let numbered = ()
-  let n = 0
-  for s in all {
-    if s.kind == "slide" { n += 1 }
-    numbered.push((slide: s, number: n))
-  }
+  // Each slide with what the deck knows about it, so the count keeps running
+  // across the page breaks. The counting itself happened once, in
+  // `presentation`; here the entries are only paired up with their slides.
+  let numbered = all.enumerate().map(((i, s)) => (slide: s, fakten: facts.at(i)))
 
   let sheets = ()
   let batch = ()
@@ -304,7 +334,7 @@
       [#block(width: w, height: h, clip: true, {
         set block(fill: aussen.fill, stroke: aussen.stroke, radius: aussen.radius)
         scale(w / geo.width * 100%, origin: top + left,
-              slide-body(item.slide, item.number, total, style, geo, t))
+              slide-body(item.slide, style, geo, t))
       }) <ts-handout-frame>]
     }
 
@@ -313,6 +343,13 @@
       // package resolves its targets per slide, and without this every applet
       // in the deck would look as if it stood on the same one.
       slide-counter.step()
+      // What the deck knows about this slide, before it is laid out: the
+      // shrunk slide draws its own chrome and reads the numbers from here,
+      // exactly as the full-size one does.
+      deck-info.update(item.fakten)
+      step-cursor.update(0)
+      step-here.update(())
+      sprite-number.update(none)
       // The slide's own `speaker-note` may overwrite this while it is laid
       // out, which is why the note is only read afterwards.
       note-state.update(item.slide.note)

--- a/src/theme.typ
+++ b/src/theme.typ
@@ -29,7 +29,7 @@
                         slide-counter, sprite-number, step-cursor, step-here,
                         ueberlauf-pruefen, umgebungs-block)
 #import "slides.typ": info
-#import "themes.typ": font-args
+#import "themes.typ": font-args, sichtbar, theme-state
 
 /// The body of one slide, background included.
 ///
@@ -103,14 +103,18 @@
     // Progress: a growing bar at the bottom or top, or a marker that
     // travels along its track: even at seventy slides that still shows
     // where you are, while the bar there only grows longer very slowly.
+    // The accent unless the ground has swallowed it. On the five bundled
+    // themes' own grounds this is the accent, byte for byte; it is the ground
+    // an inverted slide lays underneath that this answers.
+    let balken = sichtbar(t.paper, t.accent, t.strong, t.ink)
     if t.progress == "bar" {
       place(bottom + left, {
-        set rect(fill: t.accent, stroke: none)
+        set rect(fill: balken, stroke: none)
         [#rect(width: 100% * n / total, height: 2.5pt * k) <ts-slide-progress>]
       })
     } else if t.progress == "top" {
       place(top + left, {
-        set rect(fill: t.accent, stroke: none)
+        set rect(fill: balken, stroke: none)
         [#rect(width: 100% * n / total, height: 2.5pt * k) <ts-slide-progress>]
       })
     } else if t.progress == "tick" {
@@ -127,11 +131,15 @@
       // the end.
       let schritte = calc.max(1, total - 1)
       place(bottom + left, {
-        set rect(fill: t.accent.lighten(78%), stroke: none)
+        // The track the marker travels on. Lightened on a light palette,
+        // darkened on a dark one, as in `card` and `callout`: a track
+        // lightened by 78 percent is a bright band across a dark slide.
+        set rect(fill: if t.inverted { balken.darken(70%) }
+                       else { balken.lighten(78%) }, stroke: none)
         [#rect(width: 100%, height: 3pt * k) <ts-slide-progress-track>]
       })
       place(bottom + left, dx: (geo.width - breite) * (n - 1) / schritte, {
-        set rect(fill: t.accent, stroke: none)
+        set rect(fill: balken, stroke: none)
         [#rect(width: breite, height: 3pt * k) <ts-slide-progress>]
       })
     }
@@ -290,7 +298,15 @@
 /// Where a slide has a speaker note it stands in that room; where it has none,
 /// ruled lines take its place. Both are the same thing really: the space is
 /// for whatever is not on the slide itself.
-#let handout-body(all, facts, style, geo, t, per-page, overflow: "none") = {
+#let handout-body(all, facts, style, geo, t, per-page, thema: none,
+                  overflow: "none") = {
+  // Which theme a single slide is set in. A slide carrying `invert` is set in
+  // the turned palette on paper too, or the handout would show a different
+  // slide than the talk did. `presentation` hands the function in only for a
+  // deck that inverts somewhere; without it nothing per slide is written into
+  // the theme state, and a deck that never inverts builds exactly as it did.
+  let wechselt = thema != none
+  let thema = if thema == none { s => t } else { thema }
   set page(paper: "a4", margin: (x: 1.5cm, y: 1.4cm))
   set text(size: 10pt, fill: t.strong)
   let gap = 14pt
@@ -349,7 +365,8 @@
       [#block(width: w, height: h, clip: true, {
         set block(fill: aussen.fill, stroke: aussen.stroke, radius: aussen.radius)
         scale(w / geo.width * 100%, origin: top + left,
-              slide-body(item.slide, style, geo, t, overflow: overflow))
+              slide-body(item.slide, style, geo, thema(item.slide),
+                         overflow: overflow))
       }) <ts-handout-frame>]
     }
 
@@ -362,6 +379,7 @@
       // shrunk slide draws its own chrome and reads the numbers from here,
       // exactly as the full-size one does.
       deck-info.update(item.fakten)
+      if wechselt { theme-state.update(thema(item.slide)) }
       step-cursor.update(0)
       step-here.update(())
       sprite-number.update(none)

--- a/src/themes.typ
+++ b/src/themes.typ
@@ -16,6 +16,30 @@
 
 #import "config.typ": margins
 
+/// The full-bleed ground of a title or section slide.
+///
+/// A `set` rule rather than an argument, so a `show label(..): set rect(..)`
+/// in a deck reaches it. An explicit `fill:` on the rect could not be
+/// overridden by any rule.
+#let grund(farbe, marke) = {
+  set rect(fill: farbe, stroke: none)
+  if marke == "title" {
+    [#rect(width: 100%, height: 100%) <ts-title-slide-ground>]
+  } else {
+    [#rect(width: 100%, height: 100%) <ts-section-slide-ground>]
+  }
+}
+
+/// One of the short accent strokes a title or section slide is built from.
+#let zierlinie(breite, hoehe, farbe, marke) = {
+  set rect(fill: farbe, stroke: none)
+  if marke == "title" {
+    [#rect(width: breite, height: hoehe) <ts-title-slide-rule>]
+  } else {
+    [#rect(width: breite, height: hoehe) <ts-section-slide-rule>]
+  }
+}
+
 /// Font arguments that simply leave out a `none`.
 ///
 /// `text(font: none)` does not exist: anyone who does not want to
@@ -64,10 +88,10 @@
 } else { d }
 
 /// The line with author and date, as it stands under every title slide.
-#let by-line(t, s, k) = text(size: 12pt * k, fill: t.muted, {
+#let by-line(t, s, k) = text(size: 12pt * k, fill: t.muted, [#{
   s.author
   if s.date != none [ · #datum(s.date) ]
-})
+} <ts-title-slide-byline>])
 
 // ── default ────────────────────────────────────────────────────────────────
 
@@ -75,15 +99,15 @@
 #let band-title-slide(t, s, geo) = {
   let k = geo.scale
   let m = margins(geo)
-  rect(width: 100%, height: 100%, fill: t.paper, stroke: none)
+  grund(t.paper, "title")
   place(top + left, dx: m.left, dy: geo.height * 0.32, {
     stapel(
       text(..font-args(t.title-font), size: 34pt * k, weight: "bold",
-           fill: t.strong, s.title),
+           fill: t.strong, [#s.title <ts-title-slide-title>]),
       6pt * k,
-      rect(width: 190pt * k, height: 2.5pt * k, fill: t.accent, stroke: none),
+      zierlinie(190pt * k, 2.5pt * k, t.accent, "title"),
       8pt * k,
-      text(size: 17pt * k, fill: t.muted, s.subtitle),
+      text(size: 17pt * k, fill: t.muted, [#s.subtitle <ts-title-slide-subtitle>]),
     )
   })
   place(bottom + left, dx: m.left, dy: -m.bottom, by-line(t, s, k))
@@ -93,13 +117,13 @@
 #let band-section(t, s, geo) = {
   let k = geo.scale
   let m = margins(geo)
-  rect(width: 100%, height: 100%, fill: t.strong, stroke: none)
+  grund(t.strong, "section")
   place(horizon + left, dx: m.left, {
     stapel(
-      rect(width: 62pt * k, height: 2.5pt * k, fill: t.accent, stroke: none),
+      zierlinie(62pt * k, 2.5pt * k, t.accent, "section"),
       10pt * k,
       text(..font-args(t.title-font), size: 30pt * k, weight: "bold",
-           fill: white, s.title),
+           fill: white, [#s.title <ts-section-slide-title>]),
     )
   })
 }
@@ -110,17 +134,20 @@
 #let lesson-title-slide(t, s, geo) = {
   let k = geo.scale
   let m = margins(geo)
-  rect(width: 100%, height: 100%, fill: t.paper, stroke: none)
-  place(top + left, rect(width: 100%, height: 12pt * k, fill: t.accent, stroke: none))
+  grund(t.paper, "title")
+  place(top + left, {
+    set rect(fill: t.accent, stroke: none)
+    [#rect(width: 100%, height: 12pt * k) <ts-title-slide-band>]
+  })
   place(center + horizon, dy: -10pt * k, block(width: geo.width - 2 * m.left, {
     set align(center)
     stapel(
       text(..font-args(t.title-font), size: 38pt * k, weight: "bold",
-           fill: t.strong, s.title),
+           fill: t.strong, [#s.title <ts-title-slide-title>]),
       14pt * k,
-      rect(width: 130pt * k, height: 3pt * k, fill: t.accent, stroke: none),
+      zierlinie(130pt * k, 3pt * k, t.accent, "title"),
       14pt * k,
-      text(size: 18pt * k, fill: t.muted, s.subtitle),
+      text(size: 18pt * k, fill: t.muted, [#s.subtitle <ts-title-slide-subtitle>]),
     )
   }))
   place(bottom + center, dy: -m.bottom, by-line(t, s, k))
@@ -131,11 +158,15 @@
   let k = geo.scale
   let m = margins(geo)
   let balken = 16pt * k
-  rect(width: 100%, height: 100%, fill: t.accent.lighten(88%), stroke: none)
-  place(top + left, rect(width: balken, height: 100%, fill: t.accent, stroke: none))
+  grund(t.accent.lighten(88%), "section")
+  place(top + left, {
+    set rect(fill: t.accent, stroke: none)
+    [#rect(width: balken, height: 100%) <ts-section-slide-bar>]
+  })
   place(horizon + left, dx: m.left + balken,
     block(width: geo.width - 2 * m.left - balken,
-      text(..font-args(t.title-font), size: 32pt * k, weight: "bold", fill: t.strong, s.title)))
+      text(..font-args(t.title-font), size: 32pt * k, weight: "bold", fill: t.strong,
+           [#s.title <ts-section-slide-title>])))
 }
 
 // ── night ──────────────────────────────────────────────────────────────────
@@ -145,16 +176,16 @@
 #let night-title-slide(t, s, geo) = {
   let k = geo.scale
   let m = margins(geo)
-  rect(width: 100%, height: 100%, fill: t.paper, stroke: none)
+  grund(t.paper, "title")
   place(center + horizon, block(width: geo.width * 0.74, {
     set align(center)
     stapel(
       text(..font-args(t.title-font), size: 40pt * k, weight: "bold",
-           fill: t.ink, s.title),
+           fill: t.ink, [#s.title <ts-title-slide-title>]),
       16pt * k,
-      rect(width: 90pt * k, height: 2pt * k, fill: t.accent, stroke: none),
+      zierlinie(90pt * k, 2pt * k, t.accent, "title"),
       16pt * k,
-      text(size: 17pt * k, fill: t.muted, s.subtitle),
+      text(size: 17pt * k, fill: t.muted, [#s.subtitle <ts-title-slide-subtitle>]),
     )
   }))
   place(bottom + center, dy: -m.bottom, by-line(t, s, k))
@@ -163,16 +194,16 @@
 /// Two accent lines, with the title in the accent color between them.
 #let night-section(t, s, geo) = {
   let k = geo.scale
-  rect(width: 100%, height: 100%, fill: t.paper, stroke: none)
+  grund(t.paper, "section")
   place(center + horizon, block(width: geo.width * 0.56, {
     set align(center)
     stapel(
-      rect(width: 100%, height: 1pt * k, fill: t.accent, stroke: none),
+      zierlinie(100%, 1pt * k, t.accent, "section"),
       18pt * k,
       text(..font-args(t.title-font), size: 30pt * k, weight: "bold",
-           fill: t.accent, s.title),
+           fill: t.accent, [#s.title <ts-section-slide-title>]),
       18pt * k,
-      rect(width: 100%, height: 1pt * k, fill: t.accent, stroke: none),
+      zierlinie(100%, 1pt * k, t.accent, "section"),
     )
   }))
 }
@@ -183,20 +214,20 @@
 #let plain-title-slide(t, s, geo) = {
   let k = geo.scale
   let m = margins(geo)
-  rect(width: 100%, height: 100%, fill: t.paper, stroke: none)
+  grund(t.paper, "title")
   place(top + left, dx: m.left, dy: geo.height * 0.42, block(width: geo.width * 0.7, {
     stapel(
       text(..font-args(t.title-font), size: 30pt * k, fill: t.strong,
-           tracking: 0.3pt * k, s.title),
+           tracking: 0.3pt * k, [#s.title <ts-title-slide-title>]),
       12pt * k,
-      text(size: 15pt * k, fill: t.muted, s.subtitle),
+      text(size: 15pt * k, fill: t.muted, [#s.subtitle <ts-title-slide-subtitle>]),
     )
   }))
   place(bottom + left, dx: m.left, dy: -m.bottom,
-    text(size: 10pt * k, fill: t.muted, {
+    text(size: 10pt * k, fill: t.muted, [#{
       s.author
       if s.date != none [ · #datum(s.date) ]
-    }))
+    } <ts-title-slide-byline>]))
 }
 
 /// The title sits where the slide title would otherwise stand, just at
@@ -204,13 +235,13 @@
 #let plain-section(t, s, geo) = {
   let k = geo.scale
   let m = margins(geo)
-  rect(width: 100%, height: 100%, fill: t.paper, stroke: none)
+  grund(t.paper, "section")
   place(horizon + left, dx: m.left, block(width: geo.width * 0.7, {
     stapel(
       text(..font-args(t.title-font), size: 26pt * k, fill: t.strong,
-           tracking: 0.3pt * k, s.title),
+           tracking: 0.3pt * k, [#s.title <ts-section-slide-title>]),
       11pt * k,
-      rect(width: 40pt * k, height: 0.8pt * k, fill: t.muted, stroke: none),
+      zierlinie(40pt * k, 0.8pt * k, t.muted, "section"),
     )
   }))
 }
@@ -222,38 +253,39 @@
 #let editorial-title-slide(t, s, geo) = {
   let k = geo.scale
   let m = margins(geo)
-  rect(width: 100%, height: 100%, fill: t.paper, stroke: none)
+  grund(t.paper, "title")
   place(center + horizon, dy: -8pt * k, block(width: geo.width * 0.68, {
     set align(center)
     stapel(
-      rect(width: 64pt * k, height: 0.9pt * k, fill: t.accent, stroke: none),
+      zierlinie(64pt * k, 0.9pt * k, t.accent, "title"),
       18pt * k,
       text(..font-args(t.title-font), size: 34pt * k, fill: t.strong,
-           tracking: 0.5pt * k, s.title),
+           tracking: 0.5pt * k, [#s.title <ts-title-slide-title>]),
       12pt * k,
-      text(size: 16pt * k, style: "italic", fill: t.muted, s.subtitle),
+      text(size: 16pt * k, style: "italic", fill: t.muted,
+           [#s.subtitle <ts-title-slide-subtitle>]),
       20pt * k,
-      rect(width: 64pt * k, height: 0.9pt * k, fill: t.accent, stroke: none),
+      zierlinie(64pt * k, 0.9pt * k, t.accent, "title"),
     )
   }))
   place(bottom + center, dy: -m.bottom,
-    text(size: 11pt * k, fill: t.muted, tracking: 1.4pt * k, upper({
+    text(size: 11pt * k, fill: t.muted, tracking: 1.4pt * k, [#upper({
       s.author
       if s.date != none [ · #datum(s.date) ]
-    })))
+    }) <ts-title-slide-byline>]))
 }
 
 /// Full-bleed surface in the primary color, title in paper color on top.
 #let editorial-section(t, s, geo) = {
   let k = geo.scale
-  rect(width: 100%, height: 100%, fill: t.strong, stroke: none)
+  grund(t.strong, "section")
   place(center + horizon, block(width: geo.width * 0.7, {
     set align(center)
     stapel(
-      rect(width: 44pt * k, height: 0.9pt * k, fill: t.accent, stroke: none),
+      zierlinie(44pt * k, 0.9pt * k, t.accent, "section"),
       20pt * k,
       text(..font-args(t.title-font), size: 30pt * k, fill: t.paper,
-           tracking: 0.5pt * k, s.title),
+           tracking: 0.5pt * k, [#s.title <ts-section-slide-title>]),
     )
   }))
 }
@@ -277,6 +309,23 @@
 /// text takes up around 3.0% of the slide width and the title 3.9%. The
 /// earlier 19pt/23pt were at 2.3% and 2.7%: noticeably smaller than what
 /// you would want to read from the back row.
+///
+/// What the theme draws also carries labels, and those are the second way to
+/// reach it. Names follow one scheme, place first and part second. On an
+/// ordinary slide `ts-slide-ground`, `ts-slide-header-band`,
+/// `ts-slide-header-text`, `ts-slide-header-rule`, `ts-slide-title`,
+/// `ts-slide-title-rule`, `ts-slide-footer`, `ts-slide-number`,
+/// `ts-slide-footer-rule`, `ts-slide-progress` and `ts-slide-progress-track`;
+/// on the title slide `ts-title-slide-ground`, `ts-title-slide-band`,
+/// `ts-title-slide-title`, `ts-title-slide-subtitle`, `ts-title-slide-rule`
+/// and `ts-title-slide-byline`; on the section slide
+/// `ts-section-slide-ground`, `ts-section-slide-bar`,
+/// `ts-section-slide-title` and `ts-section-slide-rule`. A `show` rule on one
+/// of them changes type or fill without a key having to exist for it; the
+/// keys below stay what they are and keep the arrangement.
+///
+/// A theme that brings its own `title-slide` or `section` function draws none
+/// of those labels, and nothing warns about it.
 ///
 /// Comments must NOT go into the parameter list: tidy splits it at the
 /// commas and expects a colon in every piece; the API reference breaks

--- a/src/themes.typ
+++ b/src/themes.typ
@@ -13,8 +13,53 @@
 //
 // The second line is the whole trick to varying a theme: a theme is a
 // dictionary, and `+` overwrites individual entries.
+//
+// The eight color entries are also a *palette*, and `presentation` takes one
+// separately (`palettes.typ`). The difference is what each is for: `+` on a
+// theme reaches every entry, including the fonts and the measures, while a
+// palette reaches the colors and nothing else, and therefore composes with
+// any design. `mit-palette` at the bottom of this file is where the two meet.
 
 #import "config.typ": margins
+#import "palettes.typ": (contrast, invert-palette, palette-keys, palette-pruefen,
+                        palettes)
+
+/// The first of the given colors that is readable on `grund`, measured.
+///
+/// `strong` is the one role a palette cannot settle on its own. In
+/// `themes.default` and `themes.editorial` it is a *ground* that carries light
+/// text; in `themes.lesson` and `themes.plain` it is the color of the heading
+/// *on* the paper. No single color does both once the paper turns dark, so
+/// every place that sets `strong`, or `paper`, as text asks here instead of
+/// naming a color outright.
+///
+/// The pick is a measurement, not a lightness rule, and that distinction is
+/// the whole point. A muted sage such as `rgb("#aebdb3")` reads as "light" to
+/// a luminance rule, yet white on it measures 1.96 to 1. Here the candidates
+/// are weighed by `contrast`, and the first one that reaches 4.5 to 1 wins, so
+/// the color a theme names first is the one it keeps wherever that color
+/// works. Where none reaches it, the strongest of them is taken rather than
+/// nothing.
+#let lesbar(grund, ..kandidaten) = {
+  let ks = kandidaten.pos()
+  let gut = ks.find(c => contrast(c, grund) >= 4.5)
+  if gut != none { gut } else { ks.sorted(key: c => -contrast(c, grund)).first() }
+}
+
+/// The same for a shape rather than for text.
+///
+/// A bar, a rule, a marker carries no letterforms, so the contract asks 3.0 of
+/// it and not the 4.5 body text wants -- the same two numbers the palette
+/// report uses. Of the five bundled themes only `default` and `night` draw a
+/// progress indicator at all, and on their own grounds their accent measures
+/// 3.26 and 9.77, so both keep the accent and nothing moves. It is the ground
+/// an inverted slide puts underneath that this answers: night's cyan measures
+/// 1.59 against it.
+#let sichtbar(grund, ..kandidaten) = {
+  let ks = kandidaten.pos()
+  let gut = ks.find(c => contrast(c, grund) >= 3.0)
+  if gut != none { gut } else { ks.sorted(key: c => -contrast(c, grund)).first() }
+}
 
 /// The full-bleed ground of a title or section slide.
 ///
@@ -103,7 +148,8 @@
   place(top + left, dx: m.left, dy: geo.height * 0.32, {
     stapel(
       text(..font-args(t.title-font), size: 34pt * k, weight: "bold",
-           fill: t.strong, [#s.title <ts-title-slide-title>]),
+           fill: lesbar(t.paper, t.strong, t.ink),
+           [#s.title <ts-title-slide-title>]),
       6pt * k,
       zierlinie(190pt * k, 2.5pt * k, t.accent, "title"),
       8pt * k,
@@ -123,7 +169,8 @@
       zierlinie(62pt * k, 2.5pt * k, t.accent, "section"),
       10pt * k,
       text(..font-args(t.title-font), size: 30pt * k, weight: "bold",
-           fill: white, [#s.title <ts-section-slide-title>]),
+           fill: lesbar(t.strong, white, t.paper, t.ink),
+           [#s.title <ts-section-slide-title>]),
     )
   })
 }
@@ -143,7 +190,8 @@
     set align(center)
     stapel(
       text(..font-args(t.title-font), size: 38pt * k, weight: "bold",
-           fill: t.strong, [#s.title <ts-title-slide-title>]),
+           fill: lesbar(t.paper, t.strong, t.ink),
+           [#s.title <ts-title-slide-title>]),
       14pt * k,
       zierlinie(130pt * k, 3pt * k, t.accent, "title"),
       14pt * k,
@@ -158,14 +206,22 @@
   let k = geo.scale
   let m = margins(geo)
   let balken = 16pt * k
-  grund(t.accent.lighten(88%), "section")
+  // The tinted ground of the section slide. Lightened on a light palette,
+  // darkened on a dark one, the same switch `card` and `callout` make: an
+  // accent lightened by 88 percent is nearly white, and a full-bleed white
+  // section slide in the middle of a dark deck is a flash, not a pause.
+  grund(if t.inverted { t.accent.darken(72%) } else { t.accent.lighten(88%) },
+        "section")
   place(top + left, {
     set rect(fill: t.accent, stroke: none)
     [#rect(width: balken, height: 100%) <ts-section-slide-bar>]
   })
   place(horizon + left, dx: m.left + balken,
     block(width: geo.width - 2 * m.left - balken,
-      text(..font-args(t.title-font), size: 32pt * k, weight: "bold", fill: t.strong,
+      text(..font-args(t.title-font), size: 32pt * k, weight: "bold",
+           fill: lesbar(
+             if t.inverted { t.accent.darken(72%) } else { t.accent.lighten(88%) },
+             t.strong, t.ink),
            [#s.title <ts-section-slide-title>])))
 }
 
@@ -217,7 +273,8 @@
   grund(t.paper, "title")
   place(top + left, dx: m.left, dy: geo.height * 0.42, block(width: geo.width * 0.7, {
     stapel(
-      text(..font-args(t.title-font), size: 30pt * k, fill: t.strong,
+      text(..font-args(t.title-font), size: 30pt * k,
+           fill: lesbar(t.paper, t.strong, t.ink),
            tracking: 0.3pt * k, [#s.title <ts-title-slide-title>]),
       12pt * k,
       text(size: 15pt * k, fill: t.muted, [#s.subtitle <ts-title-slide-subtitle>]),
@@ -238,7 +295,8 @@
   grund(t.paper, "section")
   place(horizon + left, dx: m.left, block(width: geo.width * 0.7, {
     stapel(
-      text(..font-args(t.title-font), size: 26pt * k, fill: t.strong,
+      text(..font-args(t.title-font), size: 26pt * k,
+           fill: lesbar(t.paper, t.strong, t.ink),
            tracking: 0.3pt * k, [#s.title <ts-section-slide-title>]),
       11pt * k,
       zierlinie(40pt * k, 0.8pt * k, t.muted, "section"),
@@ -259,7 +317,8 @@
     stapel(
       zierlinie(64pt * k, 0.9pt * k, t.accent, "title"),
       18pt * k,
-      text(..font-args(t.title-font), size: 34pt * k, fill: t.strong,
+      text(..font-args(t.title-font), size: 34pt * k,
+           fill: lesbar(t.paper, t.strong, t.ink),
            tracking: 0.5pt * k, [#s.title <ts-title-slide-title>]),
       12pt * k,
       text(size: 16pt * k, style: "italic", fill: t.muted,
@@ -284,7 +343,8 @@
     stapel(
       zierlinie(44pt * k, 0.9pt * k, t.accent, "section"),
       20pt * k,
-      text(..font-args(t.title-font), size: 30pt * k, fill: t.paper,
+      text(..font-args(t.title-font), size: 30pt * k,
+           fill: lesbar(t.strong, t.paper, t.ink, white),
            tracking: 0.5pt * k, [#s.title <ts-section-slide-title>]),
     )
   }))
@@ -304,6 +364,15 @@
 /// rule-size rule-fill head-gap foot-gap band-height box footer
 /// footer-rule progress`) and the two whole pictures (`title-slide`,
 /// `section`).
+///
+/// The eight colors are also the entries a *palette* may carry, and that is
+/// how a theme is recolored without touching the rest of it. Two of the
+/// entries above are colors that are not palette entries, `title-fill` and
+/// `rule-fill`, and each may be written either as a color or as a function
+/// of the palette, `p => p.strong`. A color stays what it is under every
+/// palette; a function is asked again whenever one is applied, and that is
+/// what lets the title of a light theme follow into the dark. `rule-fill:
+/// none` means the accent and follows it.
 ///
 /// Font sizes: measured against Beamer and Metropolis, where the body
 /// text takes up around 3.0% of the slide width and the title 3.9%. The
@@ -346,7 +415,7 @@
   weight: "bold",
   tracking: 0pt,
   header: "band",
-  title-fill: white,
+  title-fill: p => lesbar(p.strong, white, p.paper, p.ink),
   rule-size: 0pt,
   rule-fill: none,
   head-gap: 20pt,
@@ -377,7 +446,7 @@
   font: font, title-font: if title-font == none { font } else { title-font },
   size: size, title-size: title-size, weight: weight, tracking: tracking,
   header: header, title-fill: title-fill,
-  rule-size: rule-size, rule-fill: if rule-fill == none { accent } else { rule-fill },
+  rule-size: rule-size, rule-fill: rule-fill,
   head-gap: head-gap, foot-gap: foot-gap, band-height: band-height,
   footer: footer, footer-rule: footer-rule, progress: progress, box: box,
   title-slide: title-slide, section: section,
@@ -432,7 +501,10 @@
     // color and its own size; boldness would be a third signal for the
     // same thing.
     weight: 600,
-    title-fill: rgb("#c1361c"),
+    // Written as the palette's `strong` rather than as the color itself. The
+    // value is the same one; said this way the heading follows into any
+    // palette instead of staying vermilion on a dark ground.
+    title-fill: p => lesbar(p.paper, p.strong, p.ink),
     // No line under the title. In the book, the colored line belongs to
     // the page's running header, not to the heading; placed underneath it
     // turns two things into one in two colors. The heading carries its
@@ -446,6 +518,9 @@
     // explained anything the header does not say better: it names the
     // chapter you are in, not merely the fraction.
     header: "run",
+    // The hairline under the running header. Same value as the default, said
+    // out loud so it follows a palette.
+    rule-fill: p => p.accent,
     footer: "none",
     progress: "none",
     box: "label",
@@ -469,7 +544,12 @@
     size: 19pt,
     title-size: 24pt,
     header: "plain",
-    title-fill: rgb("#5ec8f2"),
+    // The cyan carries the title on the deck's own dark ground, 9.77 to 1.
+    // On an inverted slide the ground becomes this palette's ink, and there
+    // the same cyan measures 1.59 to 1 -- the pairing the contrast report
+    // lists as night's failing one. So it is asked for rather than named, and
+    // on the dark ground the answer is still the cyan, byte for byte.
+    title-fill: p => lesbar(p.paper, p.accent, p.ink),
     head-gap: 16pt,
     footer: "number",
     progress: "top",
@@ -494,7 +574,10 @@
     weight: "medium",
     tracking: 0.8pt,
     header: "plain",
-    title-fill: luma(30%),
+    // luma(30%) written as a step off the ink, because `black.lighten(30%)`
+    // *is* luma(30%) to the byte. On a dark palette the same expression walks
+    // the other way and lifts the title off the ground instead of sinking it.
+    title-fill: p => p.ink.lighten(30%),
     head-gap: 34pt,
     foot-gap: 20pt,
     footer: "number",
@@ -530,9 +613,9 @@
     weight: "regular",
     tracking: 0.5pt,
     header: "plain",
-    title-fill: rgb("#7b2d26"),
+    title-fill: p => lesbar(p.paper, p.strong, p.ink),
     rule-size: 0.9pt,
-    rule-fill: rgb("#ded2ba"),
+    rule-fill: p => p.border,
     head-gap: 22pt,
     foot-gap: 30pt,
     footer: "center",
@@ -544,6 +627,34 @@
 )
 
 
+/// The theme with a palette laid over it, and optionally inverted.
+///
+/// The one place where a theme and a palette meet. `presentation` calls it for
+/// every deck, with an empty palette when none was given, and once more per
+/// slide that carries `invert: true`.
+///
+/// Three steps, in this order. The theme's own eight colors are read out as a
+/// palette and the given one is written over it, entry by entry, so a palette
+/// of `(accent: blue)` changes the accent and nothing else. If `invert` is
+/// set, that palette is turned around by `invert-palette`. Only then are
+/// `title-fill` and `rule-fill` resolved, so a theme that wrote them as
+/// functions sees the colors the slide will actually be set in.
+#let mit-palette(t, p, invert: false) = {
+  let farben = (:)
+  for k in palette-keys { farben.insert(k, t.at(k)) }
+  farben = farben + p
+  if invert { farben = invert-palette(farben) }
+  let aufloesen(v) = if type(v) == function { v(farben) } else { v }
+  t + farben + (
+    title-fill: aufloesen(t.title-fill),
+    // `none` has meant "the accent" since the first version and keeps meaning
+    // it. Resolved here rather than in `theme()` so that it follows a palette
+    // instead of freezing the accent the theme was built with.
+    rule-fill: if t.rule-fill == none { farben.accent } else { aufloesen(t.rule-fill) },
+  )
+}
+
+
 /// The theme currently being set under.
 ///
 /// `card` and `callout` sit *inside* the slide body and know nothing
@@ -551,4 +662,4 @@
 /// would have to be handed its colors; this way it fetches them itself.
 /// `presentation` writes it once, right at the start, and anyone using a
 /// card outside a presentation gets the default.
-#let theme-state = state("typstage-theme", themes.default)
+#let theme-state = state("typstage-theme", mit-palette(themes.default, (:)))


### PR DESCRIPTION
Neun Commits, entstanden aus dem Bericht über [mosaic](https://vincentarelbundock.github.io/mosaic/). Jeder Fund wurde von einem Agenten gebaut, von einem zweiten geprüft und die Befunde danach von Hand nachgezogen.

## Was dazugekommen ist

| | |
|---|---|
| **Label** | Jede Form, die das Paket zeichnet, trägt ein Label — 37 Stück, mit `show`-Regeln erreichbar |
| **`info()`** | Ein Deck kann lesen, was typstage über es weiß: Titel, Folien- und Schrittzahl, Abschnitt |
| **`fit()`** | Rechnet einen Block auf den Platz, den er hat. Erst die Breite anbieten, dann verkleinern |
| **`overflow`** | Ein Prüflauf vor dem Vortrag: welche Folie läuft über ihren Rumpf, ab welchem Schritt |
| **Paletten** | Farbe ist eine Palette, keine Gestaltung. Fünf Paletten, `invert:` je Folie, geprüfter WCAG-Kontrastvertrag |
| **`after: "dimmed"`** | Ein besprochener Punkt bleibt leise stehen, statt zu verschwinden |
| **Beispielprüfer** | Jedes Codebeispiel beider Handbücher wird gegen das echte Paket übersetzt, bevor die Seite entsteht |

## Wie gemessen wurde

Jeder Commit hält die Sollwerte: sechs Deck-HTMLs bytegleich zum Vorgänger, 85 PDF-Seiten pixelgleich, Schrittzahlen `24/56 · 12/24 · 12/30 · 12/30 · 12/33 · 13/28` mit leerer Fehlerliste, beide Handbücher ohne neue Warnung.

Die einzige Ausnahme ist `after: "dimmed"`, der erste Fund, der die Laufzeit anfasst: dort sind die HTMLs um exakt die 4878 Bytes größer, um die `assets/typstage-0.1.0.js` gewachsen ist, und ohne den Laufzeitblock wieder bytegleich.

## Was die Prüfrunden gefunden haben

Der Beispielprüfer fand beim ersten Lauf fünf echte Defekte in Listings, die seit jeher im Handbuch standen. Die Prüfer fanden in jeder Runde Zusagen, die der Code nicht hielt — darunter zwei Garantien, die schlicht falsch waren, und drei Zahlenbereiche, die für zehn Fälle galten und für zwanzig ausgegeben wurden. Alle behoben.

Zwei Befunde sind Korrekturen an eigenen Commits dieser Reihe: eine Zeile in `fit()` änderte den Satz bestehender Decks und wurde zurückgenommen; der Wächter für `after: "dimmed"` befragte die falsche Folie nach ihrer Schrittzahl, sobald ein Deck eine Titelfolie hat.

## Warum dieser PR

Der Seitenbau in der CI wäre am leeren Submodul-Verzeichnis von `typstage-geogebra` gestorben. Die Korrektur ist lokal nachgestellt, aber in der echten CI ungeprüft — der Build-Job dieses PR ist genau dieser Test. Der Deploy bleibt auf `main` gesperrt, die veröffentlichte Seite also unberührt.

Eine Abschlussrunde über alle neun Commits steht noch aus.