### PR TITLE
slide-level: mehr als zwei Ebenen

### DIFF
--- a/.github/scripts/pruefe-beispiele.py
+++ b/.github/scripts/pruefe-beispiele.py
@@ -60,6 +60,11 @@
 #                                 Rest muss übersetzen. Für Gegenüberstellungen
 #                                 („so — nicht so"). Übersetzt sie plötzlich, ist
 #                                 das ein Fehler, kein Erfolg.
+#     bricht=belongs_to_no_slide  Der *ganze* Block muss fehlschlagen, und zwar
+#                                 an diesem Text. Für einen Fehler, der erst im
+#                                 Zusammenhang entsteht -- `fehlt=` übersetzt
+#                                 eine Zeile für sich und sähe ihn nicht.
+#                                 Unterstriche stehen für Leerzeichen.
 #     weil=cannot stand inside    Woran sie fehlschlagen muss. Ohne diese Angabe
 #                                 zählt jeder Fehlschlag, auch ein Tippfehler
 #                                 oder eine vergessene Einbindung -- und dann
@@ -183,7 +188,7 @@ def bloecke(pfad):
 def regie_lesen(text):
   """Eine Prüfzeile in ein Wörterbuch übersetzen."""
   r = {"art": None, "aus": None, "ziel": "html", "pre": [], "davor": False,
-       "dateien": [], "fehlt": [], "weil": None}
+       "dateien": [], "fehlt": [], "weil": None, "bricht": None}
   for wort in (text or "").split():
     if wort in ("ganz", "dokument", "folgen", "folie", "argument"):
       r["art"] = wort
@@ -201,6 +206,8 @@ def regie_lesen(text):
       r["fehlt"] += [int(n) for n in wort[6:].split(",")]
     elif wort.startswith("weil="):
       r["weil"] = wort[5:].replace("_", " ")
+    elif wort.startswith("bricht="):
+      r["bricht"] = wort[7:].replace("_", " ")
     else:
       raise SystemExit("unbekanntes Wort in einer Prüfzeile: " + wort)
   return r
@@ -292,6 +299,26 @@ def pruefen(auftrag):
     if not 1 <= n <= len(zeilen):
       return {"ort": ort, "stand": "fehler", "art": art,
               "meldung": "fehlt=%d, aber der Block hat nur %d Zeilen" % (n, len(zeilen))}
+
+  # Ein Block, der als Ganzes fehlschlagen soll -- für einen Fehler, der erst
+  # aus dem Zusammenhang entsteht. Ohne das bliebe ein Fehlerpfad, den das
+  # Handbuch wörtlich beschreibt, ungeprüft; genau so ist eine Meldung
+  # monatelang unerreichbar geblieben, weil niemand sie je ausgelöst hat.
+  if regie["bricht"]:
+    geklappt, meldung = uebersetzen(
+      huelle(art, dedent(zeilen), vorspann), regie["ziel"], regie["dateien"],
+      paketpfad)
+    if geklappt:
+      return {"ort": ort, "stand": "fehler", "art": art,
+              "meldung": "sollte an „%s\" abbrechen, übersetzt aber"
+                         % regie["bricht"]}
+    if regie["bricht"] not in meldung:
+      return {"ort": ort, "stand": "fehler", "art": art,
+              "meldung": ("bricht ab, aber nicht an „%s\": %s"
+                          % (regie["bricht"],
+                             meldung.strip().splitlines()[0] if meldung.strip()
+                             else "(ohne Meldung)"))}
+    return {"ort": ort, "stand": "gut", "art": art, "fehlt": 1}
 
   # Erst der Rest ohne die Zeilen, die fehlschlagen sollen: der muss übersetzen.
   rest = "\n".join(z for i, z in enumerate(zeilen, 1) if i not in regie["fehlt"])

--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ First this.
 Then that.
 ```
 
+`slide-level:` moves the cut: with `slide-level: 3` a `=` and a `==` are both
+section slides and `===` is the slide, so a semester fits into one file with
+its transition slides falling out by themselves. `info().levels` and
+`info().outline` hand the structure back for an agenda of your own.
+
 Slides may also be handed over as arguments, `presentation(title-slide(…),
 section([…]), slide([Title])[…])`, for decks that are generated rather than
 written.
@@ -112,7 +117,7 @@ written.
 | `card`, `callout`, `side-by-side`, `tiles`, `statement` | layouts inside a slide; `tiles` staggers itself, and `side-by-side(equal: true)` makes its columns the same height |
 | `fit` | scales one block down to the room it has, for a wide table or a generated chart; no reveal may sit inside it |
 | `overflow:` | a checking pass, off by default: `"error"` builds the deck and then names every slide whose body runs over its room, with the step; `"record"` files the same as queryable metadata |
-| `info` | what the deck knows about itself: title, slide and step number, section — for a footer or a running head of your own |
+| `info` | what the deck knows about itself: title, slide and step number, section, and with `slide-level` the whole outline — for a footer, a running head or an agenda of your own |
 | `transition`, `speaker-note` | how this slide comes in, and what only you see |
 | `themes`, `theme` | the five built-in looks, and the builder behind them |
 | `palettes`, `palette:`, `invert` | colour separately from design: five bundled palettes that compose with every theme, a partial override on `presentation`, and one slide set in the palette turned around |

--- a/docs/content-en.typ
+++ b/docs/content-en.typ
@@ -111,6 +111,82 @@ following file is complete and can be typed out:
 A first-level heading is a section slide, a second-level heading is a slide,
 and the text below it is its body. That is the whole structure.
 
+== More than two levels
+
+The default cuts the deck at the second level: `=` becomes a section slide,
+`==` becomes a slide. `slide-level` moves that cut. A heading *above* it
+becomes a section slide, a heading at it or below it becomes a slide.
+
+// check: dokument
+#show-code[```typ
+#show: presentation.with(title: [Analysis I], slide-level: 3)
+= Part I -- Limits
+== Sequences
+=== What a sequence is
+A map from the naturals into the reals.
+=== Convergence
+For every epsilon there is an N.
+== Series
+=== Partial sums
+The sum of the first n terms.
+```]
+
+`= Part I` and `== Sequences` each become a section slide, every `===` becomes
+a slide. The transition slides for *both* levels come along by themselves: a
+section heading here already is the transition slide, so there is nothing to
+switch on and no hook to write.
+
+`slide-level: 1` makes every heading a slide; the deck then has no structure
+level at all.
+
+The five bundled themes draw a deeper level more quietly: the title gets
+smaller, and above it stands what the section hangs under. A theme with a
+`section` function of its own reads `s.depth` and `s.parents` off the record
+and may ignore both. Then every level looks alike, and nothing breaks.
+
+What the deck knows about its structure is in `info()`: `section` still means
+the level directly above the slide, `levels` has one entry per structure
+level, and `outline` is the whole thing. The section "`info()`: what the deck
+knows about itself" says what is in them.
+
+=== Text that belongs to no slide
+
+Between a section heading and the next heading there is no room for text. A
+section slide is a whole picture the theme draws; it has no body. Such text
+used to fall out of the deck without a word: it compiled, the slide count was
+right, and the paragraph was simply gone. Now that there is more than one kind
+of structure heading there are more chances to run into that, so compiling
+stops there with a message instead.
+
+A sentence between `= The proof` and `== The dissection` therefore aborts with
+`content between the heading "The proof" and the next one belongs to no
+slide`:
+
+// check: dokument bricht=belongs_to_no_slide
+#show-code[```typ
+#show: presentation.with()
+= The proof
+This sentence belongs to no slide and stops the compile.
+== The dissection
+```]
+
+It belongs under the slide heading:
+
+// check: dokument
+#show-code[```typ
+#show: presentation.with()
+= The proof
+== The dissection
+This sentence belongs to the slide and gets typeset.
+```]
+
+Two reservations, so that nothing here promises more than the code holds.
+First, text *before* the first heading is refused as well, but only if the deck
+has any heading at all: a body without a single heading is not a presentation
+in the heading notation, and there it is not one slide that is missing, there
+are none. Second, all of this applies to the heading notation only; whoever
+passes slides as arguments writes every body out anyway.
+
 == Two compilations
 
 The same file yields two outputs, and which one you get depends on the flags:
@@ -1708,7 +1784,59 @@ What comes back:
   [`section.number`], [Which section is running, `0` before the first],
   [`section.total`], [How many sections the deck has],
   [`section.title`], [Its title, or `none` before the first],
+  [`levels`], [One entry per structure level, outermost first. Empty at
+    `slide-level: 1`],
+  [`outline`], [The whole structure, one entry per section slide in the order
+    they come],
 )
+
+`section` always means the level directly above the slide. At the default
+`slide-level: 2` that is the only level there is, and then `section` is
+`levels.last()` without its `depth`.
+
+A deck with more than one level -- see "More than two levels" -- finds them in
+`levels` and in `outline`:
+
+#table(
+  columns: (auto, 1fr),
+  stroke: 0.5pt + luma(180),
+  table.header([*Field of an entry*], [*What is in it*]),
+  [`levels.at(i).depth`], [The heading level, `1` for `=`, `2` for `==`],
+  [`levels.at(i).title`], [The title, or `none` while no section of that level
+    is running],
+  [`levels.at(i).number`], [Which section of that level it is in the *whole*
+    deck. It never goes back, so it also reads as progress],
+  [`levels.at(i).total`], [How many sections that level has in the whole deck],
+  [`levels.at(i).index`], [Which one it is *under the same parent*, what Beamer
+    prints as `1.2`],
+  [`levels.at(i).count`], [How many siblings it has there. `index` and `count`
+    are `0` while no section of that level is running],
+  [`outline.at(j).depth`], [The same for an entry of the outline],
+  [`outline.at(j).title`], [Its title],
+  [`outline.at(j).number`], [The same count as `levels.at(..).number`.
+    Comparing the two says whether the entry is past, running or still to
+    come],
+  [`outline.at(j).here`], [Whether the slide being shown is that very entry.
+    Only a section slide can be, and only a theme's own `section` function can
+    read it there: a section slide has no body for a deck to write into],
+)
+
+A progressive agenda therefore needs no second count:
+
+// check: folie
+#show-code[```typ
+#context {
+  let d = info()
+  stack(spacing: 0.6em, ..d.outline.map(e => {
+    let running = d.levels.at(e.depth - 1).number
+    text(
+      weight: if e.number == running { "bold" } else { "regular" },
+      fill: if e.number <= running { black } else { luma(60%) },
+      [#h((e.depth - 1) * 1.4em)#e.title],
+    )
+  }))
+}
+```]
 
 One number stands deliberately apart: the speaker view and the overview count
 *every* slide, title and section slides included, while `info().slide.total`
@@ -1932,7 +2060,9 @@ The traps, in roughly the order they are usually hit.
   inside the body of a show rule produces no slide and no error either.
   Measured on a probe: one slide instead of three, and nothing said.
 / The first paragraph is missing: content before the first heading belongs to
-  no slide and appears nowhere.
+  no slide. Where it carries text, compiling stops there and says so — see
+  "Text that belongs to no slide". Where it carries none (an image, say), it
+  still goes without a word.
 / The slide titles ignore a `#set heading`: it stands after the show rule and
   they have left the region it encloses. `style:` reaches them.
 / `#pause` does nothing: it is inside a grid cell or a table. `#pause` splits
@@ -1967,7 +2097,8 @@ then media and the bridge, and last the measurements and colours.
 // `split-body`, `pause-tokens` and `apply-pauses` take the body apart and are
 // not part of the public surface.
 #show-module(read("../src/present.typ"), name: "typstage",
-             exclude: ("split-body", "pause-tokens", "apply-pauses"))
+             exclude: ("split-body", "pause-tokens", "apply-pauses",
+                       "slides-from-body", "stiller-lauf"))
 
 == Slides
 

--- a/docs/content.typ
+++ b/docs/content.typ
@@ -242,12 +242,93 @@ geänderte Nummer springt dorthin -- praktisch, um im Vortrag eine bestimmte
 Stelle sofort zu erreichen.
 
 #warning[
-  Inhalt, der vor der ersten Überschrift steht, gehört zu keiner Folie und
-  erscheint nirgends. Ebenso erreicht ein `#set heading`, das nach der
+  Inhalt, der vor der ersten Überschrift steht, gehört zu keiner Folie. Trägt
+  er Text, bricht das Übersetzen dort ab und sagt es -- siehe „Text, der zu
+  keiner Folie gehört". Trägt er keinen (ein Bild etwa), verschwindet er
+  weiterhin wortlos. Ebenso erreicht ein `#set heading`, das nach der
   Show-Regel steht, die Folientitel nicht mehr -- sie verlassen den Bereich,
   den die Regel umschließt. Für die Typografie der Folien gibt es `style` --
   siehe das Kapitel "Das eigene Aussehen".
 ]
+
+== Mehr als zwei Ebenen
+
+Die Vorgabe schneidet das Deck an der zweiten Ebene: `=` wird eine
+Abschnittsfolie, `==` eine Folie. `slide-level` verschiebt diesen Schnitt.
+Eine Überschrift *über* der Ebene wird zur Abschnittsfolie, eine Überschrift
+auf ihr oder darunter wird zur Folie.
+
+// check: dokument
+#show-code[```typ
+#show: presentation.with(title: [Analysis I], slide-level: 3)
+= Teil I -- Grenzwerte
+== Folgen
+=== Was eine Folge ist
+Eine Abbildung von den natürlichen in die reellen Zahlen.
+=== Konvergenz
+Für jedes Epsilon gibt es ein N.
+== Reihen
+=== Partialsummen
+Die Summe der ersten n Glieder.
+```]
+
+Aus `= Teil I` und `== Folgen` werden Abschnittsfolien, aus jedem `===` eine
+Folie. Die Übergangsfolien für *beide* Ebenen fallen dabei von selbst an: eine
+Abschnittsüberschrift ist hier schon die Trennfolie, es gibt also nichts
+anzuschalten und keinen Haken zu schreiben.
+
+`slide-level: 1` macht jede Überschrift zu einer Folie; das Deck hat dann
+überhaupt keine Struktur-Ebene mehr.
+
+Die fünf mitgelieferten Themes zeichnen eine tiefere Ebene ruhiger: der Titel
+wird kleiner, und darüber steht, worunter der Abschnitt hängt. Ein Theme mit
+eigener `section`-Funktion liest `s.depth` und `s.parents` vom Datensatz und
+darf beide übergehen -- dann sehen alle Ebenen gleich aus, und nichts bricht.
+
+Was das Deck über seine Gliederung weiß, steht in `info()`: `section` meint
+weiterhin die Ebene direkt über der Folie, `levels` hat einen Eintrag je
+Struktur-Ebene, und `outline` ist die ganze Gliederung. Der Abschnitt
+"`info()`: was das Deck über sich selbst weiß" sagt, was darin steht.
+
+=== Text, der zu keiner Folie gehört
+
+Zwischen einer Abschnittsüberschrift und der nächsten Überschrift ist kein
+Platz für Text. Eine Abschnittsfolie ist ein ganzes Bild, das das Theme
+zeichnet; sie hat keinen Rumpf. Früher fiel solcher Text ohne ein Wort aus dem
+Deck: es übersetzte, die Folienzahl stimmte, der Absatz war schlicht weg. Seit
+es mehr als eine Art von Struktur-Überschrift gibt, gibt es dafür auch mehr
+Gelegenheiten, und deshalb bricht das Übersetzen dort jetzt mit einer Meldung
+ab.
+
+Ein Satz zwischen `= Der Beweis` und `== Die Zerlegung` bricht also mit
+`content between the heading "Der Beweis" and the next one belongs to no
+slide` ab:
+
+// check: dokument bricht=belongs_to_no_slide
+#show-code[```typ
+#show: presentation.with()
+= Der Beweis
+Dieser Satz gehört zu keiner Folie und hält das Übersetzen an.
+== Die Zerlegung
+```]
+
+Er gehört unter die Folienüberschrift:
+
+// check: dokument
+#show-code[```typ
+#show: presentation.with()
+= Der Beweis
+== Die Zerlegung
+Dieser Satz gehört zur Folie und wird gesetzt.
+```]
+
+Zwei Vorbehalte, damit hier nicht mehr versprochen wird, als der Code hält.
+Erstens wird auch der Text *vor* der ersten Überschrift abgewiesen, aber nur
+dann, wenn das Deck überhaupt eine Überschrift hat: ein Rumpf ohne eine
+einzige Überschrift ist keine Präsentation in der Überschriften-Schreibweise,
+und dort fehlt nicht eine Folie, sondern es gibt keine. Zweitens greift das
+Ganze nur in der Überschriften-Schreibweise; wer Folien als Argumente übergibt,
+schreibt jeden Rumpf ohnehin selbst hin.
 
 == Wenn die Folien berechnet werden
 
@@ -2670,7 +2751,60 @@ Was zurückkommt:
     ersten],
   [`section.total`], [So viele Abschnitte hat das Deck],
   [`section.title`], [Sein Titel, oder `none` vor dem ersten],
+  [`levels`], [Ein Eintrag je Struktur-Ebene, von außen nach innen. Leer bei
+    `slide-level: 1`],
+  [`outline`], [Die ganze Gliederung, ein Eintrag je Abschnittsfolie in der
+    Reihenfolge, in der sie kommen],
 )
+
+`section` meint immer die Ebene direkt über der Folie. Bei der Vorgabe
+`slide-level: 2` ist das die einzige, die es gibt, und dann ist `section`
+dasselbe wie `levels.last()` ohne dessen `depth`.
+
+Wer mehr als eine Ebene hat -- siehe "Mehr als zwei Ebenen" --, findet sie in
+`levels` und in `outline`:
+
+#table(
+  columns: (auto, 1fr),
+  stroke: 0.5pt + luma(180),
+  table.header([*Feld eines Eintrags*], [*Was darin steht*]),
+  [`levels.at(i).depth`], [Die Überschriftentiefe, `1` für `=`, `2` für `==`],
+  [`levels.at(i).title`], [Der Titel, oder `none`, solange auf dieser Ebene
+    kein Abschnitt läuft],
+  [`levels.at(i).number`], [Der wievielte Abschnitt dieser Ebene im *ganzen*
+    Deck. Geht nie zurück und liest sich deshalb auch als Fortschritt],
+  [`levels.at(i).total`], [So viele Abschnitte hat diese Ebene im ganzen Deck],
+  [`levels.at(i).index`], [Der wievielte *unter demselben Elternteil* -- das,
+    was Beamer als `1.2` druckt],
+  [`levels.at(i).count`], [So viele Geschwister hat er dort. `index` und
+    `count` sind `0`, solange auf dieser Ebene kein Abschnitt läuft],
+  [`outline.at(j).depth`], [Ebendas für den Eintrag der Gliederung],
+  [`outline.at(j).title`], [Sein Titel],
+  [`outline.at(j).number`], [Dieselbe Zählung wie `levels.at(..).number`.
+    Der Vergleich beider sagt, ob der Eintrag vorbei ist, läuft oder noch
+    kommt],
+  [`outline.at(j).here`], [Ob die gezeigte Folie genau dieser Eintrag ist.
+    Nur eine Abschnittsfolie kann das sein, und lesen kann es dort nur eine
+    eigene `section`-Funktion eines Themes -- eine Abschnittsfolie hat keinen
+    Rumpf, in den ein Deck schreiben könnte],
+)
+
+Eine fortschreitende Gliederung braucht damit keine zweite Zählung:
+
+// check: folie
+#show-code[```typ
+#context {
+  let d = info()
+  stack(spacing: 0.6em, ..d.outline.map(e => {
+    let lauf = d.levels.at(e.depth - 1).number
+    text(
+      weight: if e.number == lauf { "bold" } else { "regular" },
+      fill: if e.number <= lauf { black } else { luma(60%) },
+      [#h((e.depth - 1) * 1.4em)#e.title],
+    )
+  }))
+}
+```]
 
 Eine Zahl steht bewusst daneben: Sprecheransicht und Übersicht zählen *alle*
 Folien, Titel- und Abschnittsfolien eingeschlossen, `info().slide.total` zählt
@@ -2801,7 +2935,8 @@ Medien und Brücke, zuletzt die Maße und Farben.
 // `split-body`, `pause-tokens` und `apply-pauses` zerlegen den Rumpf und
 // gehören nicht zur öffentlichen Fläche.
 #show-module(read("../src/present.typ"), name: "typstage",
-             exclude: ("split-body", "pause-tokens", "apply-pauses"))
+             exclude: ("split-body", "pause-tokens", "apply-pauses",
+                       "slides-from-body", "stiller-lauf"))
 
 == Folien
 

--- a/src/elements.typ
+++ b/src/elements.typ
@@ -139,6 +139,13 @@
   duration: auto,
   inline: false,
 ) = {
+  // `..variants` would otherwise swallow any named argument without a word: a
+  // typo in `start:` would leave the versions on the steps they happened to
+  // land on, and nothing would say why.
+  assert(variants.named().len() == 0,
+         message: "typstage: alternatives() does not know "
+                + variants.named().keys().join(", ")
+                + ". It takes start, align, enter, duration and inline.")
   let items = variants.pos()
   assert(items.len() > 0,
          message: "typstage: alternatives() wants at least one version")
@@ -276,6 +283,13 @@
   // because the list branch below leaves through a `return`.
   assert(im-fit.get() == 0, message: fit-meldung("stagger"))
   let start = if start == auto { step-cursor.get().first() + 1 } else { start }
+  // `..items` would otherwise swallow any named argument without a word: a
+  // typo in `stride:` would stagger on the default and say nothing.
+  assert(items.named().len() == 0,
+         message: "typstage: stagger() does not know "
+                + items.named().keys().join(", ")
+                + ". It takes start, stride, enter, duration, stagger, "
+                + "spacing and dim.")
   let gegeben = items.pos()
   assert(gegeben.len() > 0, message: "typstage: stagger() wants something to stagger")
 

--- a/src/layout.typ
+++ b/src/layout.typ
@@ -287,6 +287,13 @@
   // Asked here rather than left to the `anim`s below, so the message names the
   // function the deck actually wrote.
   assert(im-fit.get() == 0, message: fit-meldung("tiles"))
+  // `..items` would otherwise swallow any named argument without a word: a
+  // typo in `columns:` would lay the tiles out on the default and say nothing.
+  assert(items.named().len() == 0,
+         message: "typstage: tiles() does not know "
+                + items.named().keys().join(", ")
+                + ". It takes columns, gutter, row-gutter, at, stride, "
+                + "stagger, enter and align.")
   let kacheln = items.pos()
   assert(kacheln.len() > 0, message: "typstage: tiles() wants at least one tile")
   assert(at == auto or type(at) == int,

--- a/src/present.typ
+++ b/src/present.typ
@@ -87,6 +87,25 @@
   out
 }
 
+/// Whether a run of content between two headings holds nothing a reader would
+/// miss.
+///
+/// Not the same question as "is the run empty". Between two headings the
+/// markup always leaves a `space` and a `parbreak` behind, so every deck has
+/// such runs and counting elements would call them all content. Counting
+/// characters would not do either: an image loses as much as a sentence while
+/// carrying no text at all.
+///
+/// Asked on the pieces as they were written, before `wrap` puts a `styled`
+/// back around them. After that every run is one `styled` element, and a
+/// `#set` anywhere in the deck would make even the empty ones look like
+/// content.
+#let stiller-lauf(teile) = teile.all(c => {
+  let f = repr(c.func())
+  (f in ("space", "parbreak", "linebreak")
+   or (c.func() == text and c.text.trim() == ""))
+})
+
 /// Split a document body at its headings into slides.
 ///
 /// Two things make this harder than walking `body.children`.
@@ -117,7 +136,7 @@
     // piece. Typst closures cannot write to variables outside themselves, so
     // this is spelled out rather than put in a `flush()`.
     if boundary and run.len() > 0 {
-      out.push((kind: "content", body: wrap(run.join())))
+      out.push((kind: "content", body: wrap(run.join()), still: stiller-lauf(run)))
       run = ()
     }
     if c.func() == heading {
@@ -132,28 +151,85 @@
       run.push(c)
     }
   }
-  if run.len() > 0 { out.push((kind: "content", body: wrap(run.join()))) }
+  if run.len() > 0 {
+    out.push((kind: "content", body: wrap(run.join()), still: stiller-lauf(run)))
+  }
   out
 }
 
-#let slides-from-body(body, title, subtitle, author, date) = {
+/// Turn the tokens of a body into the deck's list of slides.
+///
+/// `slide-level` is the one rule: a heading *above* it opens a section slide,
+/// a heading at it or below it opens a slide. At the default of 2 that is
+/// character for character the old rule, `=` becomes a section and everything
+/// else a slide.
+///
+/// Deliberately not Touying's rule, where only `depth == slide-level` makes a
+/// slide and anything deeper stays content inside it. That reading would pull
+/// every `===` of an existing deck into the body of the `==` above it, and
+/// the deck would lose slides without saying so.
+#let slides-from-body(body, title, subtitle, author, date, slide-level) = {
   let out = ()
   if title != none {
     out.push(title-slide(title: title, subtitle: subtitle,
                          author: author, date: date))
   }
   let open = none
-  for tok in split-body(body, x => x) {
+  let davor = none
+  let marken = split-body(body, x => x)
+  // Whether this body is a deck in the heading notation at all. A body
+  // without a single heading is not one, and the content in it has not been
+  // lost behind a heading, it never had a slide to go to. That happens for
+  // real: a deck whose own show rule sits above this one hands its whole
+  // output down here, and refusing it would refuse a construction that loses
+  // nothing.
+  let mit-ueberschrift = marken.any(t => t.kind == "heading")
+  for tok in marken {
     if tok.kind == "heading" {
       if open != none { out.push(open); open = none }
-      if tok.depth == 1 { out.push(section(tok.body)) } else {
+      if tok.depth < slide-level {
+        out.push(section(tok.body, depth: tok.depth))
+        davor = tok.body
+      } else {
         open = (kind: "slide", title: tok.body, note: none,
                 transition: none, body: [])
       }
     } else if open != none {
       open.body = open.body + tok.body
+      // Zwei Bedingungen, und die zweite fängt den häufigsten Fall überhaupt:
+      // ein Rumpf ganz ohne Überschrift, in dem jemand einfach losgeschrieben
+      // hat. `mit-ueberschrift` allein ließ den durch -- gemessen verschwand
+      // dort ein ganzer Absatz spurlos, während die Titelfolie stehenblieb,
+      // also genau der Verlust, gegen den diese Prüfung gebaut ist.
+      //
+      // Warum die Einschränkung trotzdem nötig ist: das Handbuch stapelt an
+      // vier Stellen mehrere `#show: presentation.with(…)`, um Alternativen zu
+      // zeigen. Der äußere bekommt dann die Ausgabe des inneren als Rumpf, und
+      // die ist ein `context()` ohne einen einzigen Buchstaben. Text ist also
+      // das Merkmal, das den Schreibfehler von der gestapelten Vorführung
+      // trennt -- gemessen an beiden.
+    } else if not tok.still and (mit-ueberschrift
+                                 or plain-text(tok.body).trim() != "") {
+      // Content that belongs to no slide, and said out loud rather than
+      // dropped. It used to fall out of the deck without a word: the deck
+      // compiled, the slide count was right, and the paragraph was simply
+      // gone. With more than one structure level there are more headings it
+      // can fall behind, so the silence would get cheaper to run into.
+      // `let` statt eines `if` mitten im Ausdruck: in einem Codeblock ist eine
+      // Zeile, die mit `+` beginnt, ein unäres Plus und keine Verkettung.
+      // Genau daran ist diese Meldung nie erschienen -- das Übersetzen brach
+      // ab, aber mit "cannot apply unary '+' to string" und einem Zeigefinger
+      // in den Paketcode.
+      let wo = if davor == none {
+        "content before the first heading of the deck belongs to no slide. In the heading notation a slide begins with its heading, and here none has begun yet."
+      } else {
+        "content between the heading \"" + plain-text(davor) + "\" and the next one belongs to no slide. A section slide is a whole picture the theme draws and has no body to hold it."
+      }
+      panic("typstage: " + wo
+        + " Put the content under a slide heading, which at this deck's "
+        + "slide-level means a heading of depth " + str(slide-level)
+        + " or deeper, or take it out.")
     }
-    // Anything before the first heading belongs to no slide.
   }
   if open != none { out.push(open) }
   out
@@ -182,6 +258,34 @@
 /// typst compile deck.typ deck.html --format html --features html
 /// typst compile deck.typ deck.pdf
 /// ```
+///
+/// `slide-level:` is where the deck is cut. A heading *above* it becomes a
+/// section slide, a heading at it or below it becomes a slide. The default is
+/// 2, and that is the rule this package always had: `=` opens a section,
+/// `==` a slide.
+///
+/// ```typ
+/// #show: presentation.with(title: [Analysis], slide-level: 3)
+/// = Part I
+/// == Sequences
+/// === What a sequence is
+/// A map from the naturals.
+/// ```
+///
+/// `= Part I` and `== Sequences` each become a section slide, `===` becomes
+/// the slide. Both transition slides come for free: a section heading *is* the
+/// transition slide here, so there is nothing to switch on and no hook to
+/// write. `slide-level: 1` makes every heading a slide and leaves the deck
+/// without any structure level.
+///
+/// A deeper level is drawn more quietly by all five bundled themes, smaller
+/// and with the titles it hangs under set above it. A theme of its own reads
+/// `s.depth` and `s.parents` off the section record and may ignore both, and
+/// then every level looks alike.
+///
+/// What the deck knows about its structure is in `info()`: `section` is
+/// unchanged and always means the level directly above the slide, `levels`
+/// has one entry per structure level, and `outline` is the whole thing.
 ///
 /// `theme:` determines the whole look: colors, typeface, title bar,
 /// footer, progress, title and section slide. Bundled are `themes.default`
@@ -261,7 +365,21 @@
   margin: auto,
   handout: false,
   overflow: "none",
+  slide-level: 2,
 ) = {
+  // `..slides` would otherwise swallow any named argument without a word:
+  // `presentation(pallete: palettes.dark)` did nothing and said nothing. The
+  // same check `palette-pruefen` makes on a palette's keys.
+  assert(slides.named().len() == 0, message:
+    "typstage: presentation() does not know "
+    + slides.named().keys().join(", ")
+    + ". It takes title, subtitle, author, date, assets, theme, palette, "
+    + "transition, transition-duration, duration, style, width, height, "
+    + "margin, handout, overflow and slide-level.")
+  assert(type(slide-level) == int and slide-level >= 1, message:
+    "typstage: slide-level is the heading depth at which a heading becomes a "
+    + "slide, an integer from 1 upwards; 2 is the default. Not "
+    + repr(slide-level))
   assert(overflow in ("none", "error", "record"), message:
     "typstage: overflow is \"none\" (the default), \"error\" or \"record\", "
     + "not " + repr(overflow))
@@ -272,7 +390,7 @@
   // A single piece of content means: this is the body of a show rule, and that
   // gets split at its headings.
   let all = if given.len() == 1 and type(given.at(0)) == content {
-    slides-from-body(given.at(0), title, subtitle, author, date)
+    slides-from-body(given.at(0), title, subtitle, author, date, slide-level)
   } else {
     // The title belongs to the deck, not to one of the two notations. Whoever
     // hands slides as arguments used to lose it without a word.
@@ -294,6 +412,98 @@
          body: apply-pauses(s.body))
   })
   let total = all.filter(s => s.kind == "slide").len()
+
+  // ── The structure above the slides ──────────────────────────────────────
+  //
+  // One level per heading depth above `slide-level`. At the default of 2
+  // that is exactly the depth 1, one level, and every count below comes out
+  // the way it always did.
+  //
+  // The bound is the deeper of the two: what `slide-level` allows, and what
+  // the deck actually hands over. The second half is for the argument
+  // notation, where `section(.., depth: 2)` is legal whatever `slide-level`
+  // says, and where a level that exists but is not counted would leave the
+  // running header empty on a slide that plainly has a section.
+  let tiefe-max = calc.max(slide-level - 1, 0,
+    ..all.filter(s => s.kind == "section").map(s => s.at("depth", default: 1)))
+  let tiefen = range(1, tiefe-max + 1)
+
+  // First pass over the section slides: each one learns which titles it hangs
+  // under, and which group of siblings it stands in. A group is a run of
+  // sections of the same depth under the same parent, and it is what turns
+  // "the fourth section of the deck" into Beamer's "the second of this part".
+  //
+  // A heading closes everything that stood open below it. Without that, a
+  // slide under a fresh `= Part II` would still report the last `==` of part
+  // one as its section, and it would report it in the same breath as the new
+  // part. Typst closures cannot write to variables outside themselves, so the
+  // walk is spelled out rather than put in a `map`.
+  let abschnitte = ()
+  let offen-titel = tiefen.map(_ => none)
+  let offen-nr = tiefen.map(_ => -1)
+  for (i, s) in all.enumerate() {
+    if s.kind != "section" { continue }
+    let d = s.at("depth", default: 1)
+    abschnitte.push((
+      nr: i,
+      depth: d,
+      title: s.title,
+      parents: offen-titel.slice(0, d - 1).filter(x => x != none),
+      // The chain of open ancestors names the group; the depth has to come
+      // along, or a `==` and a `===` under the same part would share one.
+      gruppe: repr(offen-nr.slice(0, d - 1)) + "|" + str(d),
+    ))
+    offen-titel = offen-titel.enumerate().map(((j, x)) =>
+      if j == d - 1 { s.title } else if j > d - 1 { none } else { x })
+    offen-nr = offen-nr.enumerate().map(((j, x)) =>
+      if j == d - 1 { i } else if j > d - 1 { -1 } else { x })
+  }
+  // How large each group is, and how many sections each level has in the
+  // whole deck. Both are wanted *before* the walk below, since `count` and
+  // `total` are the sizes of something the slide is standing in the middle
+  // of.
+  let gruppen-groesse = (:)
+  for a in abschnitte {
+    gruppen-groesse.insert(a.gruppe, gruppen-groesse.at(a.gruppe, default: 0) + 1)
+  }
+  let tiefen-total = tiefen.map(d => abschnitte.filter(a => a.depth == d).len())
+  // Second pass: the finished level entry for each section slide.
+  let ebenen-satz = ()
+  let nummern = tiefen.map(_ => 0)
+  let laufend = (:)
+  for a in abschnitte {
+    nummern.at(a.depth - 1) += 1
+    laufend.insert(a.gruppe, laufend.at(a.gruppe, default: 0) + 1)
+    ebenen-satz.push((
+      depth: a.depth,
+      number: nummern.at(a.depth - 1),
+      total: tiefen-total.at(a.depth - 1),
+      index: laufend.at(a.gruppe),
+      count: gruppen-groesse.at(a.gruppe),
+      title: a.title,
+    ))
+  }
+  // The whole structure, in the order it comes. The same list the counting
+  // above ran on, only reduced to what a deck may read. No `query`, no second
+  // walk over the document.
+  let gliederung = abschnitte.enumerate().map(((j, a)) => (
+    depth: a.depth, number: ebenen-satz.at(j).number, title: a.title,
+  ))
+  // What a section slide hands its theme: its depth, and the titles above it.
+  // Both go on the record itself rather than into a new theme key, so a theme
+  // that ignores them draws every level alike instead of failing.
+  let all = {
+    let k = 0
+    let raus = ()
+    for s in all {
+      if s.kind != "section" { raus.push(s) } else {
+        raus.push(s + (depth: abschnitte.at(k).depth,
+                       parents: abschnitte.at(k).parents))
+        k += 1
+      }
+    }
+    raus
+  }
 
   // The theme with the palette laid over it, once for the deck and once
   // turned around. Both are worked out here rather than per slide: they are
@@ -331,19 +541,49 @@
       (title: title, subtitle: subtitle, author: author, date: date)
     }
   }
-  let sect-total = all.filter(s => s.kind == "section").len()
   let facts = ()
   let gezaehlt = 0
-  let kapitel = 0
-  let kapitel-titel = none
+  let gesehen = 0
+  // The outline as every slide sees it that is not itself a section slide.
+  // Built once, not once per slide.
+  let gliederung-still = gliederung.map(e => e + (here: false))
+  // The reading of every level before the first section slide: nothing is
+  // running, nothing has been counted, and the deck already knows how many
+  // there will be.
+  let ebenen = tiefen.map(d => (depth: d, number: 0, total: tiefen-total.at(d - 1),
+                                index: 0, count: 0, title: none))
   for (i, s) in all.enumerate() {
     if s.kind == "slide" { gezaehlt += 1 }
-    if s.kind == "section" { kapitel += 1; kapitel-titel = s.title }
+    if s.kind == "section" {
+      let e = ebenen-satz.at(gesehen)
+      gesehen += 1
+      // The level itself takes its new entry; everything below it is
+      // cleared, because no section of that depth is running under the new
+      // parent yet. `number` is the one thing that stays: it counts across
+      // the deck and never goes back, so it also reads as progress.
+      ebenen = ebenen.enumerate().map(((j, x)) =>
+        if j == e.depth - 1 { e }
+        else if j > e.depth - 1 { x + (index: 0, count: 0, title: none) }
+        else { x })
+    }
     facts.push((
       nr: i + 1,
       data: daten + (
         slide: (number: gezaehlt, total: total, numbered: s.kind == "slide"),
-        section: (number: kapitel, total: sect-total, title: kapitel-titel),
+        // The section stays what it always was: the level directly above the
+        // slide. At `slide-level: 2` that is the only level there is.
+        // A deck without any structure level reads as one before its first
+        // section, which is the answer this already gave there.
+        section: if ebenen.len() > 0 {
+          let innen = ebenen.last()
+          (number: innen.number, total: innen.total, title: innen.title)
+        } else { (number: 0, total: 0, title: none) },
+        levels: ebenen,
+        // `here` marks the one entry that *is* this slide, and only a section
+        // slide can be one. Every other slide gets the list built once above.
+        outline: if s.kind == "section" {
+          gliederung.enumerate().map(((m, e)) => e + (here: m == gesehen - 1))
+        } else { gliederung-still },
       ),
     ))
   }

--- a/src/slides.typ
+++ b/src/slides.typ
@@ -22,6 +22,13 @@
   // So that all three notations work: `slide[body]` (without a title),
   // `slide([title])[body]` and `slide(none)[body]`. A single piece is the
   // body, two are title and body.
+  // `..rest` would otherwise swallow any named argument without a word: a
+  // deck writing `slide(titel: [X])[…]` would get a slide without a title and
+  // no hint why. The same check the palette makes on its keys.
+  assert(rest.named().len() == 0,
+         message: "typstage: slide() does not know "
+                + rest.named().keys().join(", ")
+                + ". It takes title, note, transition and invert.")
   let teile = rest.pos()
   let kopf = title
   let rumpf = []
@@ -60,9 +67,19 @@
 #let invert = metadata("typstage-invert")
 
 /// A section slide.
-#let section(title, transition: none) = (
-  kind: "section", title: title, note: none, transition: transition, body: none,
-)
+///
+/// `depth` is the level in the heading hierarchy the section stands on: `1`
+/// for `=`, `2` for `==` and so on, up to one below the deck's `slide-level`.
+/// In the heading notation it comes from the heading; here it is written out.
+/// The five bundled themes draw a deeper section more quietly, and a theme of
+/// your own reads it from `s.depth`.
+#let section(title, depth: 1, transition: none) = {
+  assert(type(depth) == int and depth >= 1, message:
+    "typstage: section(depth: ..) is the heading level, an integer from 1 "
+    + "upwards, not " + repr(depth))
+  (kind: "section", title: title, depth: depth, note: none,
+   transition: transition, body: none)
+}
 
 /// The title slide.
 #let title-slide(title: [], subtitle: [], author: [], date: none) = (
@@ -124,8 +141,27 @@
 ///   first one where it covers several. On paper a slide is one page in its
 ///   final state, so `number` is `total` there.
 /// - `section.number`, `section.total`, `section.title`: which section the
-///   slide belongs to, how many the deck has, and its title. Before the first
-///   `=` heading, `number` is `0` and `title` is `none`.
+///   slide belongs to, how many the deck has, and its title. The section is
+///   always the level directly above the slide, so at the default
+///   `slide-level: 2` this is the `=` heading and nothing about it has
+///   changed. Before the first such heading, `number` is `0` and `title` is
+///   `none`. A deck at `slide-level: 1` has no structure level at all, and
+///   then all three read `0`, `0` and `none`.
+/// - `levels`: one entry per structure level, from the outermost inwards, so
+///   `levels.last()` is the same section as above and `levels.first()` the
+///   outermost part. Empty at `slide-level: 1`. Each entry carries
+///   `depth` (1 for `=`, 2 for `==`), `title` (`none` while no section of
+///   that level is running), `number` and `total` (counted across the whole
+///   deck, the way `section` counts), and `index` and `count` (counted among
+///   the siblings under the same parent, which is what Beamer prints as
+///   `1.2`). `number` never goes back, so it also reads as progress; `title`,
+///   `index` and `count` clear when the level above them moves on.
+/// - `outline`: the whole structure of the deck, one entry per section slide
+///   in the order they come, each with `depth`, `title`, `number` (the same
+///   count as in `levels`) and `here`, which is `true` only on that section
+///   slide itself. Comparing an entry's `number` with
+///   `levels.at(entry.depth - 1).number` says whether it is past, running or
+///   still to come, and that is how a progressive agenda is built.
 ///
 /// Only in a context. *Before* any presentation has run there is nothing to
 /// read and this stops with a message rather than handing out zeros. *After*

--- a/src/themes.typ
+++ b/src/themes.typ
@@ -108,12 +108,44 @@
   }
 }
 
+/// How large the title of a section slide is at a given depth.
+///
+/// One rule for all five themes, so a deck keeps the same hierarchy when it
+/// changes theme. `basis` is the size the theme sets for its outermost level.
+///
+/// Depth 1 is handed back untouched rather than multiplied by 1.0. Not out of
+/// care about floating point but out of care about the output: a deck that
+/// never names `slide-level` has only depth 1, and its section slides have to
+/// come out of this byte for byte as they did before there were levels at
+/// all. Below the third level nothing shrinks further; a fourth structure
+/// level needs `slide-level: 5`, and by then size is no longer what is
+/// missing.
+#let ebenen-groesse(basis, d, k) = if d <= 1 { basis * k } else {
+  basis * k * (0.8, 0.68).at(calc.min(d, 3) - 2)
+}
+
+/// The line above a section title that says what the section hangs under.
+///
+/// Only from the second structure level on. At the default `slide-level: 2` a
+/// deck has exactly one level, `eltern` is always empty, and no theme ever
+/// draws this.
+///
+/// The color is measured, not named: the five section slides stand on five
+/// different grounds, three of them dark. `t.muted` is the deck's own subdued
+/// color and comes first; where it does not reach 4.5 to 1 against the ground,
+/// the candidates the theme's own title falls back to take over.
+#let ebenen-pfad(eltern, grund, t, k, ..hell) = text(
+  size: 13pt * k, tracking: 0.6pt * k, weight: "regular",
+  fill: lesbar(grund, t.muted, ..hell.pos()),
+  [#upper(eltern.map(x => [#x]).join([ · ])) <ts-section-slide-parent>])
+
 // ═══════════════════════════════════════════════════════════════════════════
 //  Title and section slides
 // ═══════════════════════════════════════════════════════════════════════════
 //
 // Each of these functions receives `(t, s, geo)`: the theme, the slide
-// (with `title`, `subtitle`, `author`, `date`) and the canvas.
+// (with `title`, `subtitle`, `author`, `date`, and on a section slide
+// `depth` and `parents`) and the canvas.
 // `geo.scale` is the factor by which all measures grow along: every
 // number below is meant in points of the default canvas and gets
 // multiplied by it.
@@ -163,16 +195,37 @@
 #let band-section(t, s, geo) = {
   let k = geo.scale
   let m = margins(geo)
+  let d = s.at("depth", default: 1)
+  let eltern = s.at("parents", default: ())
   grund(t.strong, "section")
-  place(horizon + left, dx: m.left, {
-    stapel(
+  // Eine Breitengrenze, wie sie die vier anderen Themes schon haben -- ohne
+  // sie bekommt der Satz die volle Seitenbreite, um den linken Rand versetzt,
+  // und ragt über die rechte Kante; gemessen lief die Elternzeile mitten im
+  // Wort aus der Folie, und `overflow` sieht Abschnittsfolien nicht an.
+  //
+  // Aber nur, wo es Eltern gibt. Der Kasten unbedingt zu setzen legt auch bei
+  // Tiefe 1 zwei Gruppen mehr ins SVG, und `theme-default` war danach nicht
+  // mehr bytegleich -- dieselbe Falle, an der schon der Entwurf hing. Eine
+  // Abschnittsfolie ohne Eltern ist genau die von vorher und bleibt es.
+  let rahmen = if eltern.len() > 0 {
+    it => block(width: geo.width - m.left - m.right, it)
+  } else { it => it }
+  place(horizon + left, dx: m.left, rahmen({
+    // Built as a list rather than written out, so that at depth 1 exactly the
+    // three pieces of before go into `stapel` and the slide is unchanged.
+    let teile = (
       zierlinie(62pt * k, 2.5pt * k, t.accent, "section"),
       10pt * k,
-      text(..font-args(t.title-font), size: 30pt * k, weight: "bold",
-           fill: lesbar(t.strong, white, t.paper, t.ink),
+      text(..font-args(t.title-font), size: ebenen-groesse(30pt, d, k),
+           weight: "bold", fill: lesbar(t.strong, white, t.paper, t.ink),
            [#s.title <ts-section-slide-title>]),
     )
-  })
+    if eltern.len() > 0 {
+      teile = (ebenen-pfad(eltern, t.strong, t, k, white, t.paper, t.ink),
+               10pt * k) + teile
+    }
+    stapel(..teile)
+  }))
 }
 
 // ── lesson ─────────────────────────────────────────────────────────────────
@@ -216,13 +269,23 @@
     set rect(fill: t.accent, stroke: none)
     [#rect(width: balken, height: 100%) <ts-section-slide-bar>]
   })
+  let d = s.at("depth", default: 1)
+  let eltern = s.at("parents", default: ())
+  let boden = if t.inverted { t.accent.darken(72%) } else { t.accent.lighten(88%) }
   place(horizon + left, dx: m.left + balken,
-    block(width: geo.width - 2 * m.left - balken,
-      text(..font-args(t.title-font), size: 32pt * k, weight: "bold",
-           fill: lesbar(
-             if t.inverted { t.accent.darken(72%) } else { t.accent.lighten(88%) },
-             t.strong, t.ink),
-           [#s.title <ts-section-slide-title>])))
+    block(width: geo.width - 2 * m.left - balken, {
+      let titel = text(..font-args(t.title-font),
+           size: ebenen-groesse(32pt, d, k), weight: "bold",
+           fill: lesbar(boden, t.strong, t.ink),
+           [#s.title <ts-section-slide-title>])
+      // At depth 1 the title stands as bare as before. No `block` around it:
+      // in the PDF that changes nothing, but in the HTML it adds a group and
+      // fourteen bytes, and the deck of yesterday is then no longer the deck
+      // of today.
+      if eltern.len() == 0 { titel } else {
+        stapel(ebenen-pfad(eltern, boden, t, k, t.strong, t.ink), 8pt * k, titel)
+      }
+    }))
 }
 
 // ── night ──────────────────────────────────────────────────────────────────
@@ -250,17 +313,23 @@
 /// Two accent lines, with the title in the accent color between them.
 #let night-section(t, s, geo) = {
   let k = geo.scale
+  let d = s.at("depth", default: 1)
+  let eltern = s.at("parents", default: ())
   grund(t.paper, "section")
   place(center + horizon, block(width: geo.width * 0.56, {
     set align(center)
-    stapel(
+    let teile = (
       zierlinie(100%, 1pt * k, t.accent, "section"),
       18pt * k,
-      text(..font-args(t.title-font), size: 30pt * k, weight: "bold",
-           fill: t.accent, [#s.title <ts-section-slide-title>]),
+      text(..font-args(t.title-font), size: ebenen-groesse(30pt, d, k),
+           weight: "bold", fill: t.accent, [#s.title <ts-section-slide-title>]),
       18pt * k,
       zierlinie(100%, 1pt * k, t.accent, "section"),
     )
+    if eltern.len() > 0 {
+      teile = (ebenen-pfad(eltern, t.paper, t, k, t.accent, t.ink), 14pt * k) + teile
+    }
+    stapel(..teile)
   }))
 }
 
@@ -292,15 +361,21 @@
 #let plain-section(t, s, geo) = {
   let k = geo.scale
   let m = margins(geo)
+  let d = s.at("depth", default: 1)
+  let eltern = s.at("parents", default: ())
   grund(t.paper, "section")
   place(horizon + left, dx: m.left, block(width: geo.width * 0.7, {
-    stapel(
-      text(..font-args(t.title-font), size: 26pt * k,
+    let teile = (
+      text(..font-args(t.title-font), size: ebenen-groesse(26pt, d, k),
            fill: lesbar(t.paper, t.strong, t.ink),
            tracking: 0.3pt * k, [#s.title <ts-section-slide-title>]),
       11pt * k,
       zierlinie(40pt * k, 0.8pt * k, t.muted, "section"),
     )
+    if eltern.len() > 0 {
+      teile = (ebenen-pfad(eltern, t.paper, t, k, t.strong, t.ink), 9pt * k) + teile
+    }
+    stapel(..teile)
   }))
 }
 
@@ -337,16 +412,23 @@
 /// Full-bleed surface in the primary color, title in paper color on top.
 #let editorial-section(t, s, geo) = {
   let k = geo.scale
+  let d = s.at("depth", default: 1)
+  let eltern = s.at("parents", default: ())
   grund(t.strong, "section")
   place(center + horizon, block(width: geo.width * 0.7, {
     set align(center)
-    stapel(
+    let teile = (
       zierlinie(44pt * k, 0.9pt * k, t.accent, "section"),
       20pt * k,
-      text(..font-args(t.title-font), size: 30pt * k,
+      text(..font-args(t.title-font), size: ebenen-groesse(30pt, d, k),
            fill: lesbar(t.strong, t.paper, t.ink, white),
            tracking: 0.5pt * k, [#s.title <ts-section-slide-title>]),
     )
+    if eltern.len() > 0 {
+      teile = (ebenen-pfad(eltern, t.strong, t, k, t.paper, t.ink, white),
+               16pt * k) + teile
+    }
+    stapel(..teile)
   }))
 }
 
@@ -389,12 +471,21 @@
 /// `ts-title-slide-title`, `ts-title-slide-subtitle`, `ts-title-slide-rule`
 /// and `ts-title-slide-byline`; on the section slide
 /// `ts-section-slide-ground`, `ts-section-slide-bar`,
-/// `ts-section-slide-title` and `ts-section-slide-rule`. A `show` rule on one
-/// of them changes type or fill without a key having to exist for it; the
-/// keys below stay what they are and keep the arrangement.
+/// `ts-section-slide-title`, `ts-section-slide-rule` and
+/// `ts-section-slide-parent`. A `show` rule on one of them changes type or
+/// fill without a key having to exist for it; the keys below stay what they
+/// are and keep the arrangement.
+///
+/// The last of those is the line naming the sections a deeper section hangs
+/// under. It exists only from the second structure level on, so a deck at the
+/// default `slide-level: 2` never draws it.
 ///
 /// A theme that brings its own `title-slide` or `section` function draws none
-/// of those labels, and nothing warns about it.
+/// of those labels, and nothing warns about it. Such a `section` function
+/// receives the section record, and there `s.depth` is the heading level and
+/// `s.parents` are the titles above it, outermost first. A function that reads
+/// neither draws every level alike; nothing breaks, the hierarchy is simply
+/// not shown.
 ///
 /// Comments must NOT go into the parameter list: tidy splits it at the
 /// commas and expects a colon in every piece; the API reference breaks


### PR DESCRIPTION
Antwort auf eine Forumsanfrage: `=` gibt eine Abschnittsfolie, `==` eine Folie — für einen Vortrag genau richtig, für eine ganze Vorlesungsreihe in einer Datei zu wenig.

```typ
#show: presentation.with(slide-level: 3)   // = Teil / == Abschnitt / === Folie
```

**Die Regel ist ein Satz:** Überschriften flacher als `slide-level` werden Strukturfolien, alles ab `slide-level` wird eine Folie. Vorgabe 2 ist zeichenweise die alte Regel. Bewusst **nicht** Touyings Regel — die würde `===` in den Rumpf schlucken und heutige Decks brechen.

**Übergangsfolien für beide Ebenen fallen an, ohne Hook**, weil bei uns eine `=`-Überschrift schon die Trennfolie *ist*. Weder Beamers `\AtBeginSection` noch Touyings vier `new-*-slide-fn`.

## `navigator` haben wir geprüft und verworfen

Der Forumsschreiber schlug sein Paket vor. Es rechnet mit `loc.page()` und `loc.position().y` — im HTML-Export gibt es beides nicht, gemessen liefert dort jede Position `page=1, y=0pt`. In einem echten Deck mit vier Folien: **0 von 4 richtig**, in 0.1.5 wie in 0.1.7. Dazu hat typstage gar keine Überschriften (`query(heading).len() == 0`), auf die seine Show-Regel greifen könnte.

Übernommen ist die Idee des `mapping`, nicht der Code.

## Zwei Altfehler mitgenommen

Inhalt zwischen einer Strukturüberschrift und der nächsten verschwand **stumm** — jetzt bricht das Übersetzen ab und sagt, welche Überschrift gemeint ist. Und Vertipper in Sammelparametern wurden geschluckt: `presentation(pallete: …)` tat nichts und sagte nichts.

## Was die Prüfrunde gefunden hat

Fünf Fehler, alle behoben. Der schwerste: **die neue Meldung erschien nie** — in einem Codeblock ist eine Zeile, die mit `+` beginnt, ein unäres Plus. Das Übersetzen brach ab, aber mit einem Typst-Innenfehler, während beide Handbücher die Meldung wörtlich versprachen.

Damit das nicht wiederkommt, kennt `pruefe-beispiele.py` jetzt `bricht=<grund>`: der ganze Block muss fehlschlagen, und zwar an diesem Text. Das alte `fehlt=` übersetzt eine Zeile für sich und hätte den Fall nie gesehen.

Dazu ließ die Einschränkung den häufigsten Fall offen (Rumpf ganz ohne Überschrift — ein Absatz verschwand spurlos, die Titelfolie blieb), zwei interne Helfer standen in der öffentlichen API-Referenz, beide Handbücher widersprachen sich an einer stehengebliebenen Stelle, und die Elternzeile lief im Vorgabe-Theme aus der Folie.

## Gemessen

Sechs Deck-HTMLs bytegleich, 85 PDF-Seiten bei 150 dpi bytegleich, `pruefe-decks.js` über sieben Decks ohne Abweichung, Beispielprüfer von 117 auf **125** übersetzte Beispiele bei 0 Fehlern. Der Prüfer hat zusätzlich Firefox gefahren und ein dreistufiges Deck durch den Prüflauf geschickt — die Lücke, die beim letzten Fund noch offen war.