### PR TITLE
prefers-reduced-motion: Deckkraft bleibt, Ortsveränderung fällt weg

### DIFF
--- a/.github/scripts/pruefe-decks.js
+++ b/.github/scripts/pruefe-decks.js
@@ -388,6 +388,25 @@ const kurz = s => (s == null ? "nichts" : (s.length > 220 ? s.slice(0, 217) + ".
   const bericht = []; let schlecht = 0;
   if (bildZiel) fs.mkdirSync(bildZiel, { recursive: true });
 
+  // Die Sollwerte sind ohne „Bewegung reduzieren" aufgenommen, und die
+  // Laufzeit hält sich daran: unter der Einstellung fliegt kein Morph, also
+  // steht `flieger` bei allen sieben Decks auf 0. Der Lauf schlägt dann fehl,
+  // aber mit vierzehn Zeilen „soll 82, ist 0", aus denen niemand die Ursache
+  // liest. Gemessen mit --force-prefers-reduced-motion: genau diese vierzehn.
+  // Darum einmal gefragt und beim Namen genannt. Nur `flieger` weicht ab;
+  // sichtbar, gedimmt, grund, hash, sprecher und satz halten, weil die
+  // Einstellung den Weg wegnimmt und nicht das Ziel.
+  await laden(b, "about:blank");
+  const leiser = await b.ev(
+    "matchMedia('(prefers-reduced-motion: reduce)').matches");
+  if (leiser) {
+    console.error("FEHLER: Dieser Browser meldet prefers-reduced-motion: "
+      + "reduce. Dann fliegt kein Magic Move und flieger steht überall auf 0. "
+      + "Der Lauf will einen Browser ohne die Einstellung.");
+    await b.ende();
+    process.exit(2);
+  }
+
   for (const d of decks) {
     const z = { deck: d.name, maengel: [] };
     // Jedes Deck bekommt eine frische Seite. Ein Sprung, der nur den Hash

--- a/README.md
+++ b/README.md
@@ -207,6 +207,14 @@ phone or tablet the same works with a finger, and so does swiping: right to
 left brings the next slide, the other way the previous one. The address bar
 carries the current step (`#12`), so a reloaded window stands where it stood.
 
+Where the operating system asks for **reduced motion**, the deck obliges:
+opacity stays, travel goes. Entrances and slide transitions become plain
+cross-fades of the same length, the magic move does not fly, and a flip book
+stands still on one frame. Dimming stays as it is, and a video keeps playing.
+The setting is read afresh on every step, so it takes effect at once; there is
+nothing to configure and no way for a deck to overrule it. See "Less motion" in
+the manual.
+
 ## The speaker view
 
 `n` opens the same file a second time, with `#speaker` on the address, in a

--- a/assets/typstage-0.1.0.js
+++ b/assets/typstage-0.1.0.js
@@ -383,6 +383,25 @@
     return svg ? marken(SLIDES[i], svg.getBoundingClientRect()) : {};
   }
 
+  // ── Less motion ───────────────────────────────────────────────────────────
+  //
+  // `prefers-reduced-motion: reduce` is set by the person at the machine, in
+  // the operating system, and the browser hands it on. It asks for less
+  // motion, not for less deck: what this runtime drops is travel, and only
+  // travel. Opacity stays everywhere, because a fade says "this is new"
+  // without carrying anything across the screen, and that saying is the
+  // whole job of an entrance.
+  //
+  // Read afresh at every use rather than latched at load. Someone who turns
+  // the setting on during a talk gets the next step under the new rule, and
+  // a flipbook already running stops within a frame; turning it off again
+  // lets everything back in the same way. That costs a media-query lookup
+  // per step, which is nothing, and saves a listener plus the state behind
+  // it.
+  var WENIGER = window.matchMedia
+    ? window.matchMedia("(prefers-reduced-motion: reduce)") : null;
+  function wenigerBewegung() { return !!(WENIGER && WENIGER.matches); }
+
   // ── Effects ───────────────────────────────────────────────────────────────
   var EFFECT = {
     "fade":       [{ opacity: 0 }, { opacity: 1 }],
@@ -404,12 +423,24 @@
     el.getAnimations().forEach(function (a) { try { a.cancel(); } catch (e) {} });
   }
 
+  // The effect, with its travel taken out when less motion is asked for.
+  // Every entry of the table above names an opacity in both of its two
+  // states, so stripping it down to that leaves a plain fade and never an
+  // empty pair. What goes with the rest is `blur`'s blur: it does not move,
+  // but it is decoration on top of the fade, and the fade already carries
+  // everything the effect has to say.
+  function effekt(name) {
+    var f = EFFECT[name] || EFFECT["fade"];
+    if (!wenigerBewegung()) return f;
+    return [{ opacity: f[0].opacity }, { opacity: f[1].opacity }];
+  }
+
   function fadeIn(el, name, dur, delay) {
     clearAnims(el);
     // "none" means no effect. Animating from 1 to 1 would not merely be
     // pointless: played backwards it would keep the element visible.
     if (name === "none") { el.style.opacity = "1"; return; }
-    var f = EFFECT[name] || EFFECT["fade"];
+    var f = effekt(name);
     el.style.opacity = "";
     var a = el.animate([f[0], f[1]],
       { duration: dur, delay: delay, easing: EASE, fill: "both" });
@@ -436,7 +467,7 @@
   function fadeOut(el, name, dur, von) {
     clearAnims(el);
     if (name === "none") { el.style.opacity = "0"; return; }
-    var f = EFFECT[name] || EFFECT["fade"];
+    var f = effekt(name);
     var ab = f[1];
     // Leaving out of the dimmed state starts where the element stands. Taken
     // from the effect's full end value it would flash back to full strength
@@ -756,6 +787,13 @@
   }
 
   function fly(fromSlide, toSlide, fallback) {
+    // Magic move is travel and nothing but travel: the point of it is that
+    // the eye follows a shape from where it stood to where it now stands.
+    // Asked for less motion there is nothing left of it worth keeping, so
+    // the slide change falls back to the ordinary transition. `false` says
+    // "no morph happened", the same answer a slide pair without a matching
+    // name gives, and it is the same route a jump already takes.
+    if (wenigerBewegung()) return false;
     flyTimers.forEach(function (t) { clearTimeout(t); });
     flyTimers = [];
     finishTransitionNow();
@@ -947,15 +985,35 @@
       var t = ticking[k];
       var n = +t.el.dataset.frames, fps = +t.el.dataset.fps || 30;
       if (!n) continue;
-      // With the clock pinned the start time drops out as well. Otherwise the
-      // frame would still depend on when the slide was entered.
-      var i = Math.floor((current - (PRUEFUHR === null ? t.t0 : 0)) / 1000 * fps);
-      if (t.el.dataset.pingpong === "1") {
-        var p = n > 1 ? 2 * n - 2 : 1;
-        var m = i % p;
-        i = m < n ? m : p - m;
-      } else if (t.el.dataset.loop === "0") { i = Math.min(i, n - 1); }
-      else { i = i % n; }
+      var i;
+      if (wenigerBewegung()) {
+        // Frozen on one frame. A looping flipbook is the loudest thing this
+        // package can put on a slide: it runs from the moment the slide
+        // comes up until the moment it goes, and it pulls the eye the whole
+        // while, including while someone is talking beside it.
+        //
+        // Which frame it freezes on is not a matter of taste. A flipbook
+        // that does not loop plays once and comes to rest on its last frame,
+        // and that resting frame is its finished state; it stays the
+        // finished state, only the way there falls away. One that loops or
+        // ping-pongs has no rest to come to, and there frame 0 is the right
+        // answer twice over: it is the frame Typst put in the box before any
+        // clock started, and it is the frame the handout shows on paper.
+        //
+        // `pingpong` beats `loop` here, exactly as it does below.
+        i = (t.el.dataset.pingpong !== "1" && t.el.dataset.loop === "0")
+          ? n - 1 : 0;
+      } else {
+        // With the clock pinned the start time drops out as well. Otherwise the
+        // frame would still depend on when the slide was entered.
+        i = Math.floor((current - (PRUEFUHR === null ? t.t0 : 0)) / 1000 * fps);
+        if (t.el.dataset.pingpong === "1") {
+          var p = n > 1 ? 2 * n - 2 : 1;
+          var m = i % p;
+          i = m < n ? m : p - m;
+        } else if (t.el.dataset.loop === "0") { i = Math.min(i, n - 1); }
+        else { i = i % n; }
+      }
       if (i === t.letztes) continue;
       t.letztes = i;
       var kinder = t.el.children;
@@ -2293,6 +2351,13 @@
 
     ELN.fort.textContent = (st.slide + 1) + " / " + SLIDES.length;
     ELN.fortSchritt.textContent = (current + 1) + " / " + STEPS.length;
+    // The bar's right edge travels across it, so with less motion asked for
+    // it jumps to its new place instead of gliding there. Set here rather
+    // than as a media query in the stylesheet, so one predicate answers the
+    // question for the whole runtime and the two halves cannot drift apart.
+    // The empty string takes the inline value away again and hands the bar
+    // back to the rule in the stylesheet.
+    ELN.balken.style.transition = wenigerBewegung() ? "none" : "";
     ELN.balken.style.width =
       (STEPS.length < 2 ? 100 : (current * 100 / (STEPS.length - 1))) + "%";
 
@@ -2552,6 +2617,14 @@
     var o = asSpec(hasMorph ? "fade"
                                : (attr(later, "transition") || CFG.transition));
     var bau = TRANSITION[o.kind] === undefined ? TRANSITION["fade"] : TRANSITION[o.kind];
+    // Asked for less motion, every transition becomes the cross-fade. All the
+    // others move the whole slide, and a slide is the largest thing on the
+    // screen: `slide` and `push` and `cover` carry it across, `zoom` grows it,
+    // `flip` and `cube` turn it, `iris` and `wipe` drag an edge over it. The
+    // fade keeps what a transition is actually for, which is to mark the cut
+    // between one slide and the next, and it keeps it at the same length.
+    // `"none"` stays untouched, because nothing is already what it does.
+    if (bau && wenigerBewegung()) bau = TRANSITION["fade"];
     if (instant || !bau) return;
 
     var d = CFG.transitionDuration;

--- a/docs/content-en.typ
+++ b/docs/content-en.typ
@@ -610,7 +610,8 @@ motion that Typst can draw and CSS cannot: a curve being traced, a mechanism
 turning, a diagram assembling itself.
 
 `loop`, `pingpong` and `still` decide how it plays and which frame stands on
-paper.
+paper. If the viewer has turned on "reduce motion" in their operating system,
+it never starts playing at all; see "Less motion".
 
 #warning[
   Every frame is really typeset. Twenty-four frames are twenty-four layouts and
@@ -888,6 +889,72 @@ Measured in Chrome, Firefox 154 and Safari 26: the six example decks run
 through in all three with the same numbers, and the speaker view opens in all
 three on one keypress. A *real* keypress is the condition, since `window.open`
 without a user gesture would fall to the popup blocker everywhere.
+
+== Less motion
+
+Someone who has turned on "reduce motion" in their operating system gets a
+quieter deck. The browser passes the setting on as
+`prefers-reduced-motion: reduce`, and the runtime asks for it afresh on every
+step and on every frame: turning it on in the middle of a talk takes effect on
+the next key press, and a running flip book stops within a frame. There is
+nothing to configure for it, neither in the deck nor at build time.
+
+The setting says "less motion", not "no motion", and that is how it is
+implemented here: *opacity stays, travel goes.* An entrance still says "this is
+new", which is what an entrance is for, but nothing crosses the slide any more.
+
+#table(
+  columns: (auto, 1fr),
+  inset: 6pt,
+  stroke: (x, y) => if y == 0 { (bottom: 0.6pt) } else { (bottom: 0.3pt + luma(80%)) },
+  table.header([What], [What becomes of it]),
+  [Entrances],
+  [Every effect keeps its opacity and loses its travel: `fade-up`, `fade-down`,
+   `fade-left`, `fade-right`, `scale`, `scale-down`, `rise` and `blur` become a
+   plain cross-fade. `fade` and `none` are left as they are. `duration` and
+   `delay` do not change.],
+  [Slide transitions],
+  [Every kind but `none` becomes the cross-fade, over the same
+   `transition-duration`. `none` stays the hard cut.],
+  [Magic move],
+  [Does not happen. Nothing flies, and the slide changes the way it would
+   change without a morph.],
+  [Flip book],
+  [Stands still on one frame. Without `loop` and without `pingpong` that is the
+   last one, where it would have come to rest anyway; only the way there falls
+   away. With `loop` or `pingpong` it is frame zero. `still` does not apply:
+   the frame for paper is typeset content and is not in the HTML at all, which
+   carries only the frames themselves.],
+  [`after: "dimmed"`],
+  [Stays. A point stepping back changes its opacity and does not move.],
+  [The progress bar in the speaker view],
+  [Jumps to its new width instead of gliding there.],
+)
+
+Two things are deliberately left alone.
+
+*Video.* A video is content, not decoration, and switching it off would take
+something away rather than calm it down. Whoever does not want it to start by
+itself writes `autoplay: false`; whoever gives controls leaves the decision to
+the viewer.
+
+*Embedded documents.* What sits inside an `embed` or is driven over the bridge
+is a foreign document with a style of its own, and the runtime does not reach
+into it. The setting does reach it, though: inside the frame,
+`matchMedia("(prefers-reduced-motion: reduce)").matches` is true as well.
+Anyone animating something in an embedded document therefore writes their own
+`@media` rule there. The signal board in the `theme-night` example does not,
+and its blinking carries on under the setting.
+
+#info[
+  There is no switch with which a deck can overrule the setting. Such a switch
+  would be half a line of work, but it would answer the wrong question: the
+  package cannot know whether a motion is essential, and whoever believes
+  theirs is would turn it on everywhere. Where a motion really does carry the
+  argument -- the flip book in `theme-default`, which walks a quantity
+  continuously through zero -- it belongs in words as well, and those are read
+  by the people who never see it run.
+]
 
 = Three outputs from one source
 
@@ -2106,7 +2173,10 @@ then media and the bridge, and last the measurements and colours.
 
 == Revealing, moving, staggering
 
-#show-module(read("../src/elements.typ"), name: "typstage")
+// `anim-kern` is the checked inside of `anim`. `stagger` uses it from
+// within, and `lib.typ` does not hand it out.
+#show-module(read("../src/elements.typ"), name: "typstage",
+             exclude: ("anim-kern",))
 
 == Layouts
 

--- a/docs/content.typ
+++ b/docs/content.typ
@@ -1137,7 +1137,9 @@ schaltet sie nur weiter.
 Abspielen (Vorgabe 30). `loop` ist an und wiederholt von vorn; `pingpong` läuft
 statt dessen vor und zurück und geht dem `loop` vor. Ist beides aus, bleibt das
 letzte Bild stehen. Auf Papier steht ein einziges: `render(0.0)`, oder was
-`still` an seine Stelle setzt.
+`still` an seine Stelle setzt. Hat der Zuschauer im Betriebssystem
+"Bewegung reduzieren" eingeschaltet, läuft das Daumenkino gar nicht erst los --
+siehe "Weniger Bewegung".
 
 #warning[
   Jedes Einzelbild wird wirklich gesetzt. 24 Bilder heißen 24 Layouts und 24
@@ -1412,6 +1414,75 @@ abgeschaltet werden.
   Eine unbekannte Art bricht den Bau nicht ab, sondern wird im Browser zur
   Überblendung. Ein Tippfehler in `#transition("iirs")` fällt also erst auf,
   wenn nichts geschieht.
+]
+
+== Weniger Bewegung
+
+Wer im Betriebssystem "Bewegung reduzieren" eingeschaltet hat, bekommt ein
+ruhigeres Deck. Der Browser reicht die Einstellung als
+`prefers-reduced-motion: reduce` durch, und die Laufzeit fragt sie bei jedem
+Schritt und bei jedem Einzelbild neu ab: Wer sie mitten im Vortrag umlegt,
+sieht die Wirkung beim nächsten Tastendruck, und ein laufendes Daumenkino hält
+innerhalb eines Bildes an. Einzustellen gibt es dafür nichts, weder im Deck
+noch beim Bauen.
+
+Die Einstellung heißt "weniger Bewegung", nicht "keine Bewegung", und so ist
+sie hier auch umgesetzt: *Deckkraft bleibt, Ortsveränderung fällt weg.* Eine
+Einblendung sagt weiterhin "das hier ist neu" -- das ist ihre Aufgabe --, aber
+nichts wandert dabei mehr über die Folie.
+
+#table(
+  columns: (auto, 1fr),
+  inset: 6pt,
+  stroke: (x, y) => if y == 0 { (bottom: 0.6pt) } else { (bottom: 0.3pt + luma(80%)) },
+  table.header([Was], [Was daraus wird]),
+  [Einblendungen],
+  [Jeder Effekt behält seine Deckkraft und verliert seinen Weg: `fade-up`,
+   `fade-down`, `fade-left`, `fade-right`, `scale`, `scale-down`, `rise` und
+   `blur` werden zur schlichten Überblendung. `fade` und `none` bleiben, wie
+   sie sind. `duration` und `delay` ändern sich nicht.],
+  [Folienübergänge],
+  [Jede Art außer `none` wird zur Überblendung, in derselben
+   `transition-duration`. `none` bleibt der harte Schnitt.],
+  [Magic Move],
+  [Fällt aus. Es fliegt nichts, und die Folie wechselt so, wie sie es ohne
+   Morph täte.],
+  [Daumenkino],
+  [Steht auf einem Bild still. Ohne `loop` und ohne `pingpong` ist es das
+   letzte -- dort bliebe es ohnehin stehen, es fällt nur der Weg dorthin weg.
+   Mit `loop` oder `pingpong` ist es das erste. `still` gilt dabei nicht: das
+   Bild fürs Papier ist gesetzter Inhalt und steht gar nicht in der HTML, in
+   der nur die Einzelbilder liegen.],
+  [`after: "dimmed"`],
+  [Bleibt. Ein Punkt, der zurücktritt, ändert seine Deckkraft und rührt sich
+   nicht von der Stelle.],
+  [Fortschrittsbalken der Sprecheransicht],
+  [Springt auf seine neue Breite, statt hinzugleiten.],
+)
+
+Zwei Dinge bleiben mit Absicht unangetastet.
+
+*Video.* Ein Video ist Inhalt, keine Verzierung, und es abzuschalten hieße,
+etwas wegzunehmen statt es zu beruhigen. Wer nicht will, dass es von selbst
+anläuft, schreibt `autoplay: false`; wer Bedienelemente gibt, überlässt die
+Entscheidung dem Zuschauer.
+
+*Eingebettete Dokumente.* Was in `embed` steckt oder über die Brücke bedient
+wird, ist ein fremdes Dokument mit eigenem Stil, und die Laufzeit greift nicht
+hinein. Die Einstellung erreicht es trotzdem: Auch dort ist
+`matchMedia("(prefers-reduced-motion: reduce)").matches` wahr. Wer in einem
+eingebetteten Dokument etwas animiert, schreibt dort also seine eigene
+`@media`-Regel dafür. Im Beispiel `theme-night` tut das Ampelbrett das nicht,
+und sein Blinken läuft unter der Einstellung weiter.
+
+#info[
+  Es gibt keinen Schalter, mit dem ein Deck die Einstellung überstimmt. Ein
+  solcher Schalter wäre nur einen Halbsatz Arbeit, aber er beantwortete die
+  falsche Frage: Ob eine Bewegung unentbehrlich ist, weiß das Paket nicht, und
+  wer sie für unentbehrlich hält, schaltete ihn überall an. Wo eine Bewegung
+  wirklich das Argument trägt -- das Daumenkino in `theme-default`, das eine
+  Größe stetig durch die Null führt --, gehört sie zusätzlich in Worte, und die
+  liest auch, wer sie nicht laufen sieht.
 ]
 
 = Aus einer Quelle drei Ausgaben
@@ -2944,7 +3015,10 @@ Medien und Brücke, zuletzt die Maße und Farben.
 
 == Einblenden, Bewegen, Staffeln
 
-#show-module(read("../src/elements.typ"), name: "typstage")
+// `anim-kern` ist das geprüfte Innere von `anim`. `stagger` benutzt es von
+// innen, `lib.typ` reicht es nicht hinaus.
+#show-module(read("../src/elements.typ"), name: "typstage",
+             exclude: ("anim-kern",))
 
 == Layouts
 

--- a/src/elements.typ
+++ b/src/elements.typ
@@ -4,6 +4,28 @@
                         offenes-ende, pin-index, pin-marker, selector,
                         step-cursor, track)
 
+/// What `anim` does once its arguments have been checked.
+///
+/// Split out for `stagger`, and for one reason: `dim-freiwillig`. An element
+/// written by hand with `after: "dimmed"` whose range ends with the slide is a
+/// mistake -- it would rest dim on a step that never comes -- and the check at
+/// the end of the document says so. A `stagger(dim: true)` produces exactly
+/// that shape for its *last* point on purpose: the point being talked about
+/// stays bright, and dims only if the deck goes on. So its points say they may
+/// end with the slide, and the late check leaves them alone. The flag rides in
+/// the sprite record rather than in `extra`, which becomes markup attributes.
+#let anim-kern(body, at: auto, enter: "fade-up", exit: "fade",
+               after: "hidden", duration: auto, delay: 0,
+               dim-freiwillig: false) = track(
+  "anim", body, at: at, dim-freiwillig: dim-freiwillig, extra: (
+    enter: enter, exit: exit, delay: delay,
+    duration: if duration == auto { none } else { duration },
+    // Only the departure from the default travels into the markup. `hidden`
+    // is what every sprite has always done after its range, and writing it
+    // out would put a new attribute on every element of every deck.
+    after: if after == "dimmed" { after } else { none },
+  ))
+
 /// Reveal content on particular steps.
 ///
 /// `at` is a step selector. `auto`, the default, takes the next free step,
@@ -35,28 +57,11 @@
 /// the slide, and an element that never leaves has no after; the package says
 /// so instead of doing nothing. `at: "3"` is that one step, `at: "2-3"` a
 /// range.
-/// What `anim` does once its arguments have been checked.
 ///
-/// Split out for `stagger`, and for one reason: `dim-freiwillig`. An element
-/// written by hand with `after: "dimmed"` whose range ends with the slide is a
-/// mistake -- it would rest dim on a step that never comes -- and the check at
-/// the end of the document says so. A `stagger(dim: true)` produces exactly
-/// that shape for its *last* point on purpose: the point being talked about
-/// stays bright, and dims only if the deck goes on. So its points say they may
-/// end with the slide, and the late check leaves them alone. The flag rides in
-/// the sprite record rather than in `extra`, which becomes markup attributes.
-#let anim-kern(body, at: auto, enter: "fade-up", exit: "fade",
-               after: "hidden", duration: auto, delay: 0,
-               dim-freiwillig: false) = track(
-  "anim", body, at: at, dim-freiwillig: dim-freiwillig, extra: (
-    enter: enter, exit: exit, delay: delay,
-    duration: if duration == auto { none } else { duration },
-    // Only the departure from the default travels into the markup. `hidden`
-    // is what every sprite has always done after its range, and writing it
-    // out would put a new attribute on every element of every deck.
-    after: if after == "dimmed" { after } else { none },
-  ))
-
+/// Under `prefers-reduced-motion: reduce` every effect keeps its opacity and
+/// loses its travel, so `enter` and `exit` become a plain cross-fade of the
+/// same length. `after: "dimmed"` is unaffected: it changes opacity and
+/// nothing else. See the manual.
 #let anim(
   body,
   at: auto,
@@ -101,6 +106,9 @@
 /// when the formula should appear together with its tile. It is allowed
 /// exactly when the preceding slide carries no morph of the same name; the
 /// package checks this at compile time and speaks up when it does not hold.
+///
+/// Under `prefers-reduced-motion: reduce` nothing flies. The slide changes the
+/// way it would change without a morph. See the manual.
 #let morph(name, body, at: "1-", duration: 900, match: "auto", inline: true) = track(
   "morph", body, at: at, inline: inline,
   // `fly`, not `duration`: this is the duration of the *flight*, and the

--- a/src/media.typ
+++ b/src/media.typ
@@ -158,6 +158,10 @@
 /// `render` receives `t` running from 0.0 to 1.0. Every frame is rendered by
 /// Typst: CeTZ, Fletcher, equations, anything Typst can do. The frames sit in
 /// the file as SVG and stay sharp at any size.
+///
+/// Under `prefers-reduced-motion: reduce` it does not play. It stands on its
+/// last frame without `loop` and without `pingpong`, and on frame zero
+/// otherwise. See the manual.
 #let flipbook(
   render,
   frames: 24,

--- a/src/slides.typ
+++ b/src/slides.typ
@@ -106,6 +106,9 @@
 ///
 /// Backwards each one runs as a true reversal. If a morph meets the slide it
 /// cross-fades regardless: the movement is then carried by the morph.
+///
+/// Under `prefers-reduced-motion: reduce` every kind but `"none"` becomes the
+/// cross-fade, over the same duration. See the manual.
 #let transition(kind, ..spec) = transition-state.update((kind: kind) + spec.named())
 
 /// What the deck knows about itself, read from inside a slide.


### PR DESCRIPTION
Die Einstellung kam im ganzen Paket nicht vor. Gemessen mit `reduce` in drei Engines: sie ist `true`, das Daumenkino lief trotzdem weiter — und `flipbook` steht per Vorgabe auf `loop: true`, eine Kreisbewegung läuft also vom Folienaufruf bis zum Folienwechsel durch und zieht den Blick.

## Der Leitsatz

**Eine Einblendung sagt „das hier ist neu", und das erledigt sie ohne Weg. Eine Endlosschleife hat keine solche Aufgabe.**

| | |
|---|---|
| Effekttabelle | Deckkraft bleibt, Weg und Unschärfe fallen weg — jeder Eintrag nennt in beiden Zuständen eine Deckkraft, es bleibt also immer eine echte Überblendung |
| Folienübergänge | jede Art außer `none` wird zur Überblendung, gleiche Dauer |
| Magic Move | fällt aus. Er *ist* nichts als Weg |
| Daumenkino | ein stehendes Bild |
| `after: "dimmed"` | **unverändert** — eine Zustandsänderung, keine Bewegung |
| Video | bleibt: Inhalt, kein Zierat |

**Keine Übersteuerung.** Ein Deck-Schalter beantwortet die falsche Frage: ob eine Bewegung unentbehrlich ist, weiß das Paket nicht, und wer es glaubt, schaltet ihn überall an.

## Gemessen unter `reduce`, je Chromium, Firefox und WebKit

Daumenkino von 25 verschiedenen Bildern auf **1**; Einblendung von 33 transform-Stufen und 29 Orten auf je **1**, Deckkraft weiter 33 Stufen; alle elf Übergangsarten von 27 Stufen auf **1**; Magic Move von 82 Geistern auf **0**; `dimmed` identisch. Ohne `reduce` alles unverändert. Der Rückfallpfad wurde ausgelöst, nicht behauptet.

**Kein Byte CSS**: eine CSS-Regel hätte den Satz-Fingerabdruck verschoben, dessen Linux-Wert von hier aus nicht neu aufzunehmen ist. Deshalb entscheidet das Prädikat auch über den Fortschrittsbalken, per Inline-Stil — eine Quelle der Wahrheit statt zweier.

## Regression

`js +4397 B`, sechs Decks ohne Laufzeitblock bytegleich mit genau diesem Zuwachs, 85 PDF-Seiten pixelgleich, Beispielprüfer 0 Fehler, `pruefe-decks.js` ohne Abweichung.

Neu darin: `--force-prefers-reduced-motion`. Der erzwungene Fehllauf war zugleich die stärkste Messung — alle `sichtbar`-Listen, Gründe, Hash und Satz hielten, **nur** `flieger` ging auf 0. Der Beleg, dass die Einstellung den Weg wegnimmt und nicht das Ziel.