### PR TITLE
Adaptive Gruppen: aufdecken in der Reihenfolge, in der genannt wird

### DIFF
--- a/.github/scripts/decklauf/pruefdeck.typ
+++ b/.github/scripts/decklauf/pruefdeck.typ
@@ -128,3 +128,20 @@ Ein dritter.
 #v(1fr)
 
 #speaker-note[Eine Notiz, damit die Sprecheransicht etwas zu zeigen hat.]
+
+= Adaptiv
+
+== Freie Reihenfolge
+// Eine adaptive Gruppe. Sie deckt nichts von selbst auf: alle Punkte stehen
+// beiseite, bis eine Ziffer sie ruft. Fuer den Prueflauf heisst das, dass
+// `sichtbar` auf diesen Schritten null gedimmte und null gezeichnete Elemente
+// meldet -- faellt der Wächter aus, der sie beiseitestellt, kaemen sie von
+// selbst und die Reihe wuerde umfallen.
+#adaptiv("probe", start: 2)[
+  - erster Punkt
+  - zweiter Punkt
+  - dritter Punkt
+]
+#adaptiv-schicht("probe", 1, [Beiwerk zum ersten])
+#adaptiv-schicht("probe", 2, [Beiwerk zum zweiten])
+#adaptiv-schicht("probe", 3, [Beiwerk zum dritten])

--- a/.github/scripts/decklauf/soll.json
+++ b/.github/scripts/decklauf/soll.json
@@ -38,13 +38,10 @@
   "Browser keine Zahl. Nach einem Typst-Wechsel darf er neu gesetzt werden,",
   "aber nur nachdem jemand nachgesehen hat, was sich geändert hat.",
   "",
-  "satz, satzBytes und sprecher haengen an den Schriften des Rechners und nicht",
-  "am Paket. Wo die Plattformen sich einig sind, steht eine schlichte Zahl, und",
-  "dann wird auch plattformuebergreifend verglichen. Geteilt wird erst, wo eine",
-  "Plattform nachweislich abweicht -- heute nur theme-night.sprecher und der",
-  "Satz-Fingerabdruck des Pruefdecks. Die linux-Werte stammen aus den ersten",
-  "beiden CI-Laeufen dieses Prueflaufs, in denen alle sieben Decks sonst ok",
-  "meldeten; ein Ubuntu-Laeufer setzt theme-night mit einer Glyphe weniger."
+  "Das Pruefdeck ist um eine adaptive Gruppe gewachsen; die linux-Werte von satz",
+  "und satzBytes gehoerten zum alten Stand und sind deshalb entfernt. Der naechste",
+  "CI-Lauf faellt daran um und nennt die neuen -- das ist beabsichtigt: eine Zahl,",
+  "die niemand gemessen hat, gehoert nicht in einen Sollstand."
  ],
  "decks": {
   "tour": {
@@ -634,9 +631,9 @@
    "fehler": []
   },
   "pruefdeck": {
-   "folien": 13,
-   "schritte": 21,
-   "elemente": 10,
+   "folien": 15,
+   "schritte": 26,
+   "elemente": 16,
    "flieger": 2,
    "fliegerRueck": 2,
    "hash": 8,
@@ -655,6 +652,8 @@
     "#0f1319",
     "#0c2733",
     "#0f1319",
+    "#0f1319",
+    "#0c2733",
     "#0f1319"
    ],
    "sichtbar": [
@@ -678,9 +677,19 @@
     "8/4·0/0",
     "8/4·0/0",
     "9/4·1/0",
-    "10/4·1/0"
+    "10/4·1/0",
+    "10/4·0/0",
+    "10/4·0/0",
+    "10/4·0/0",
+    "10/4·0/0",
+    "10/4·0/0"
    ],
    "sichtbarRueck": [
+    "10/4·0/0",
+    "10/4·0/0",
+    "10/4·0/0",
+    "10/4·0/0",
+    "10/4·1/0",
     "10/4·1/0",
     "10/4·0/0",
     "10/4·0/0",
@@ -704,12 +713,10 @@
    ],
    "fehler": [],
    "satz": {
-    "darwin": "8e355be08071f7c8",
-    "linux": "070d0e2da7d3159b"
+    "darwin": "ab308e9c86036597"
    },
    "satzBytes": {
-    "darwin": 546292,
-    "linux": 500912
+    "darwin": 644853
    }
   }
  }

--- a/.github/scripts/decklauf/soll.json
+++ b/.github/scripts/decklauf/soll.json
@@ -39,9 +39,10 @@
   "aber nur nachdem jemand nachgesehen hat, was sich geändert hat.",
   "",
   "Das Pruefdeck ist um eine adaptive Gruppe gewachsen; die linux-Werte von satz",
-  "und satzBytes gehoerten zum alten Stand und sind deshalb entfernt. Der naechste",
-  "CI-Lauf faellt daran um und nennt die neuen -- das ist beabsichtigt: eine Zahl,",
-  "die niemand gemessen hat, gehoert nicht in einen Sollstand."
+  "",
+  "Die linux-Werte stammen aus dem CI-Lauf, der sie gemeldet hat, nachdem das",
+  "Pruefdeck um eine adaptive Gruppe gewachsen war. Der Lauf meldete dort alle",
+  "sieben Decks als ok und nannte nur diese beiden Felder als nicht verglichen."
  ],
  "decks": {
   "tour": {
@@ -713,10 +714,12 @@
    ],
    "fehler": [],
    "satz": {
-    "darwin": "ab308e9c86036597"
+    "darwin": "ab308e9c86036597",
+    "linux": "32a21adbb85e76eb"
    },
    "satzBytes": {
-    "darwin": 644853
+    "darwin": 644853,
+    "linux": 585084
    }
   }
  }

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ written.
 | `card`, `callout`, `side-by-side`, `tiles`, `statement` | layouts inside a slide; `tiles` staggers itself, and `side-by-side(equal: true)` makes its columns the same height |
 | `fit` | scales one block down to the room it has, for a wide table or a generated chart; no reveal may sit inside it |
 | `overflow:` | a checking pass, off by default: `"error"` builds the deck and then names every slide whose body runs over its room, with the step; `"record"` files the same as queryable metadata |
+| `adaptiv`, `adaptiv-schicht` | reveal points in the order a class calls them out; the digits `1` to `9` choose, and anything hung on the same step travels with the point |
 | `info` | what the deck knows about itself: title, slide and step number, section, and with `slide-level` the whole outline — for a footer, a running head or an agenda of your own |
 | `transition`, `speaker-note` | how this slide comes in, and what only you see |
 | `themes`, `theme` | the five built-in looks, and the builder behind them |

--- a/assets/typstage-0.1.0.js
+++ b/assets/typstage-0.1.0.js
@@ -2468,6 +2468,11 @@
     sprecherStand();
     tinteStand();
     mark();
+    // Last, because `ruhe` above has just written an opacity onto every
+    // element: a point still waiting to be called out would otherwise be
+    // invisible to the speaker as well, and there is nothing to choose from
+    // in an empty column.
+    adSprecher();
   }
 
   // ── Slide transitions ─────────────────────────────────────────────────────
@@ -2883,8 +2888,152 @@
     var n = t.tagName.toLowerCase();
     return n === "input" || n === "textarea" || n === "select" || !!t.isContentEditable;
   }
+
+  // ── Adaptive groups ────────────────────────────────────────────────────────
+  //
+  // Points a class calls out in whatever order they come. Every member of a
+  // group carries `data-ad` (its name) and `data-ad-nr` (which point it
+  // belongs to); a point and everything tied to it -- a drawing layer, a
+  // sentence beside it -- share one number and therefore one step. Swapping
+  // the step moves them together, so no separate link is needed.
+  //
+  // The group owns as many steps as it has points. Which point gets which of
+  // them is decided here, at the keyboard; the count never changes, and with
+  // it neither the progress bar, nor `info().step.total`, nor the overflow
+  // check, nor the handout.
+  var AD = {};
+
+  function adSammeln() {
+    AD = {};
+    [].forEach.call(document.querySelectorAll(".ts-el[data-ad]"), function (el) {
+      var name = el.dataset.ad;
+      var g = AD[name] || (AD[name] = { reihen: {}, plaetze: [], folge: [] });
+      var nr = +el.dataset.adNr;
+      (g.reihen[nr] || (g.reihen[nr] = [])).push(el);
+      // The step the point was written for. Remembered once, because
+      // `data-at` is what gets rewritten below.
+      if (!el.dataset.adPlatz) el.dataset.adPlatz = el.dataset.at;
+    });
+    Object.keys(AD).forEach(function (name) {
+      var g = AD[name];
+      g.plaetze = Object.keys(g.reihen)
+        .map(function (nr) { return g.reihen[nr][0].dataset.adPlatz; })
+        .sort(function (a, b) { return parseInt(a, 10) - parseInt(b, 10); });
+      g.aus = (STEPS.length + 2) + "-";
+    });
+    // Nothing has been called out yet, so every point stands aside. Without
+    // this the first point would simply appear on its own step, which is the
+    // behaviour an adaptive group exists to replace.
+    Object.keys(AD).forEach(function (name) { adStellen(name, false); });
+    adSprecher();
+  }
+
+  // `malen` is false while the deck is being set up: there is no current step
+  // yet, and `goto` would have nothing to go to.
+  function adStellen(name, malen) {
+    var g = AD[name];
+    if (!g) return;
+    Object.keys(g.reihen).forEach(function (nr) {
+      var p = g.folge.indexOf(+nr);
+      var at = p >= 0 ? g.plaetze[p] : g.aus;
+      g.reihen[nr].forEach(function (el) { el.dataset.at = at; });
+    });
+    adSprecher();
+    if (malen !== false) goto(current, true);
+  }
+
+  // The digits, and only in the speaker view. A point that has not been called
+  // out yet is invisible in the hall -- that is the whole idea -- but the
+  // speaker has to see what there is to choose from, and which digit picks
+  // it. So it stands there pale, with its number in front of it.
+  //
+  // Written as inline style rather than as a CSS rule, and not out of taste:
+  // the stylesheet is embedded in every deck, so a rule would move the
+  // typeset fingerprint the deck check keeps per platform -- and the Linux
+  // value cannot be re-recorded from here.
+  function adSprecher() {
+    if (ROLLE !== "speaker") return;
+    Object.keys(AD).forEach(function (name) {
+      var g = AD[name];
+      Object.keys(g.reihen).forEach(function (nr) {
+        var offen = g.folge.indexOf(+nr) < 0;
+        g.reihen[nr].forEach(function (el, i) {
+          el.style.opacity = offen ? "0.3" : "";
+          el.style.visibility = offen ? "visible" : "";
+          // One badge per point, on the first member. The layer that travels
+          // with it needs no second number.
+          // Beside the point, not inside it. A badge inside inherits the
+          // element's opacity, and a point waiting to be called stands at 0.3
+          // -- measured, the digit was as pale as the text it labels and no
+          // help at all. As a sibling it keeps its own strength and takes the
+          // point's own left/top, which `setzen` has already written.
+          // Nur das erste Mitglied raeumt auf und legt an. Lief das Aufraeumen
+          // fuer jedes Mitglied, entfernte die Schicht die Marke, die ihr
+          // eigener Punkt gerade angelegt hatte -- gemessen: keine einzige
+          // Ziffer im Bild, obwohl jede angelegt worden war.
+          if (i > 0) return;
+          var eig = el.parentNode
+            && el.parentNode.querySelector(':scope > .ts-ad-nr[data-fuer="' + name + "-" + nr + '"]');
+          if (eig) eig.remove();
+          if (!offen) return;
+          var b = document.createElement("span");
+          b.className = "ts-ad-nr";
+          b.dataset.fuer = name + "-" + nr;
+          b.textContent = nr;
+          b.style.left = el.style.left;
+          b.style.top = el.style.top;
+          // An explicit colour, not `currentColor`: beside `color:#fff` in the
+          // same declaration that resolves to white, and the badge was white
+          // on white -- measured, invisible in the speaker view.
+          //
+          // Placed inside the element, not to its left: a point sits at the
+          // left edge of its column, and anything outside is clipped away.
+          var wo = "left:" + (el.style.left || "0") + ";top:" + (el.style.top || "0") + ";";
+          b.style.cssText = "position:absolute;" + wo
+            + "font:700 0.72em/1.55 system-ui,sans-serif;width:1.55em;"
+            + "height:1.55em;border-radius:50%;text-align:center;"
+            + "background:#eb5e28;color:#fff;opacity:1;"
+            // Auf den Aufzaehlungspunkt, nicht daneben: die Ziffer nimmt den
+            // Platz des Punktes ein, den sie ohnehin ersetzt, und die Zeile
+            // rueckt nicht.
+            + "pointer-events:none;z-index:5;transform:translate(-12%,6%)";
+          if (el.parentNode) el.parentNode.appendChild(b);
+        });
+      });
+    });
+  }
+
+  // Which groups are on the slide the deck is standing on.
+  function adHier() {
+    var sec = SLIDES[STEPS[current].slide];
+    return Object.keys(AD).filter(function (name) {
+      return Object.keys(AD[name].reihen).some(function (nr) {
+        return AD[name].reihen[nr].some(function (el) { return sec.contains(el); });
+      });
+    });
+  }
+
+  // A digit reveals that point of the group on this slide. Pressed again it
+  // does nothing: taking a point back is what paging backwards is for.
+  function adTaste(ziffer) {
+    var namen = adHier();
+    if (!namen.length) return false;
+    var g = AD[namen[0]];
+    if (!(ziffer in g.reihen)) return false;
+    if (g.folge.indexOf(ziffer) >= 0) return false;
+    g.folge.push(ziffer);
+    adStellen(namen[0], false);
+    // And go there. Naming a point and then having to press onwards would be
+    // two moves for one thought; the step is the one the point just took, so
+    // the count and the progress bar say the same as before.
+    var platz = parseInt(g.plaetze[g.folge.length - 1], 10) - 1;
+    goto(platz, false);
+    return true;
+  }
+
   addEventListener("keydown", function (e) {
     if (tippt(e)) return;
+    if (/^[1-9]$/.test(e.key) && adTaste(+e.key)) { e.preventDefault(); return; }
     if (e.key === "ArrowRight" || e.key === "PageDown" || e.key === " ") { goto(current + 1); e.preventDefault(); }
     else if (e.key === "ArrowLeft" || e.key === "PageUp") { goto(current - 1); e.preventDefault(); }
     else if (e.key === "Home") goto(0, true);
@@ -2999,6 +3148,10 @@
   });
 
   fit();
+  // Before the first `goto`, because the very first step already has to know
+  // whether a point of an adaptive group has been called out yet -- none has,
+  // so all of them stand aside until a digit says otherwise.
+  adSammeln();
   // The speaker view starts at the first slide and waits for the talk to
   // tell it where it stands. The talk itself takes the number from the
   // hash, this one time and never again after that.

--- a/docs/content-en.typ
+++ b/docs/content-en.typ
@@ -342,6 +342,71 @@ slide has a further step after it, because then the walk has moved on from it
 too. And `stride: 0`, which puts every point on one step, makes them all dim
 together on the next.
 
+== Revealing in the order it is called out
+
+Some points have no order. What a graph shows, what stands out in an
+experiment, which ways there are to work something out -- a class names those
+in whatever order they come, and a deck that reveals them in *its* order makes
+the teacher either wait or reshuffle.
+
+`adaptiv` turns that round: the digits `1` to `9` reveal whatever was just
+named.
+
+// check: folie
+#show-code[```typ
+#adaptiv("readings", start: 2)[
+  - positive and negative values
+  - lowest and highest value
+  - falling and rising
+]
+```]
+
+The group takes a name, because something else can point at it. It owns as many
+steps as it has points, and the order changes nothing about that -- the
+progress bar, `info().step.total`, the overflow check and the handout are all
+untouched.
+
+Set, the list keeps its reading order: a point not yet named holds its place, so
+nothing jumps when it arrives later.
+
+=== What appears together with a point
+
+A point rarely stands alone. `adaptiv-schicht` hangs something on the same step
+-- a drawing layer, a picture, a sentence beside it:
+
+// check: folie davor
+#show-code[```typ
+#adaptiv-schicht("readings", 1, [and what goes with it])
+```]
+
+Nothing is linked to do that: the point and the layer share a step, and
+swapping the step moves both. You can hang as much on a point as you like.
+
+The group has to stand *before* its layers in the source -- a layer looks up
+which step its point was given. Standing after them, the package says so rather
+than quietly doing nothing.
+
+#tip[
+  For a CeTZ drawing that grows with the points, draw the scaffolding once and
+  every layer as its own complete drawing, with everything else made invisible
+  through `cetz.draw.hide(rest, bounds: true)` but still counting towards the
+  bounds. All layers then lie exactly on top of each other and the graph holds
+  still, in whatever order it grows -- measured on a pair of axes with three
+  label layers, every subset comes to
+  347.9 pt #sym.times 329.71 pt.
+
+  A layer carries *only its own contribution*, no grid and no base curve.
+  Otherwise the layer set last paints over the first, and that regardless of
+  the order things are revealed in.
+]
+
+#info[
+  The digits work only while an adaptive group stands on the slide. In the
+  speaker view every point still open stands there pale, with its digit on the
+  bullet; in the hall it is invisible. Pressed a second time a digit does
+  nothing -- taking a point back is what paging backwards is for.
+]
+
 == One piece on a step of its own
 
 `anim` wraps exactly what should appear and says when:

--- a/docs/content.typ
+++ b/docs/content.typ
@@ -598,6 +598,73 @@ statt einer Folge.
 ]
 ```]
 
+== Aufdecken in der Reihenfolge, in der es genannt wird
+
+Manche Stichpunkte haben keine Ordnung. Was ein Graph zeigt, was an einem
+Versuch auffällt, welche Rechenwege es gibt -- die Klasse nennt das in
+beliebiger Folge, und ein Deck, das sie in seiner Folge aufdeckt, zwingt die
+Lehrkraft, entweder zu warten oder umzusortieren.
+
+`adaptiv` dreht das um: die Ziffern `1` bis `9` decken auf, was gerade genannt
+wurde.
+
+// check: folie
+#show-code[```typ
+#adaptiv("ablesen", start: 2)[
+  - positive und negative Werte
+  - tiefster und höchster Wert
+  - Abnahme und Zunahme
+]
+```]
+
+Die Gruppe braucht einen Namen, weil sich etwas anderes auf sie beziehen kann.
+Sie verbraucht so viele Schritte, wie sie Punkte hat, und die Reihenfolge ändert
+daran nichts -- Fortschritt, `info().step.total`, die Überlaufprüfung und das
+Handout bleiben also unberührt.
+
+Beim Setzen behält die Liste ihre Leserichtung: ein noch ungenannter Punkt hält
+seinen Platz frei, damit nichts springt, wenn er später dazukommt.
+
+=== Was mit dem Punkt zugleich erscheint
+
+Ein Stichpunkt steht selten allein. `adaptiv-schicht` hängt etwas an denselben
+Schritt -- eine Zeichenschicht, ein Bild, einen Satz daneben:
+
+// check: folie davor
+#show-code[```typ
+#adaptiv-schicht("ablesen", 1, [dazu das Passende])
+```]
+
+Verknüpft wird dabei nichts: Punkt und Schicht teilen sich einen Schritt, und
+wer den Schritt vertauscht, bewegt beide. Man kann an einen Punkt hängen, so
+viel man will.
+
+Die Gruppe muss im Quelltext *vor* ihren Schichten stehen -- eine Schicht liest
+nach, welchen Schritt ihr Punkt bekommen hat. Steht sie davor, sagt das Paket
+es, statt still nichts zu tun.
+
+#tip[
+  Für eine CeTZ-Zeichnung, die mit den Punkten wächst, zeichnet man das
+  Gerüst einmal und jede Schicht als eigene, vollständige Zeichnung, in der
+  alles andere über `cetz.draw.hide(rest, bounds: true)` unsichtbar, aber für
+  den Ausschnitt maßgebend bleibt. Dann liegen alle Schichten deckungsgleich
+  übereinander und der Graph steht still, egal in welcher Reihenfolge er
+  wächst -- gemessen an einem Achsenkreuz mit drei Beschriftungsschichten:
+  jede Teilmenge misst 347,9 pt #sym.times 329,71 pt.
+
+  Eine Schicht trägt dabei *nur ihren eigenen Beitrag*, kein Gitter und keine
+  Grundkurve. Sonst übermalt die zuletzt gesetzte Schicht die erste, und zwar
+  unabhängig davon, in welcher Reihenfolge aufgedeckt wird.
+]
+
+#info[
+  Die Ziffern wirken nur, solange eine adaptive Gruppe auf der Folie steht.
+  In der Sprecheransicht steht jeder noch offene Punkt blass da, mit seiner
+  Ziffer auf dem Aufzählungspunkt; im Saal ist er unsichtbar. Ein zweites Mal
+  gedrückt tut eine Ziffer nichts -- einen Punkt zurückzunehmen ist das, wofür
+  das Zurückblättern da ist.
+]
+
 == Ein einzelnes Stück auf einem eigenen Schritt
 
 `anim` blendet beliebigen Inhalt auf bestimmten Schritten ein. Das ist das

--- a/src/elements.typ
+++ b/src/elements.typ
@@ -1,6 +1,6 @@
 // Appearing, moving and staggering.
 
-#import "internal.typ": (fit-meldung, html-output, im-deck, im-fit, name-of,
+#import "internal.typ": (adaptiv-gruppen, fit-meldung, html-output, im-deck, im-fit, name-of,
                         offenes-ende, pin-index, pin-marker, selector,
                         step-cursor, track)
 
@@ -16,8 +16,11 @@
 /// the sprite record rather than in `extra`, which becomes markup attributes.
 #let anim-kern(body, at: auto, enter: "fade-up", exit: "fade",
                after: "hidden", duration: auto, delay: 0,
-               dim-freiwillig: false) = track(
+               dim-freiwillig: false, ad: none, ad-nr: none) = track(
   "anim", body, at: at, dim-freiwillig: dim-freiwillig, extra: (
+    // Membership in an adaptive group. `none` never travels into the markup,
+    // so an ordinary element gains no new attribute.
+    ad: ad, "ad-nr": ad-nr,
     enter: enter, exit: exit, delay: delay,
     duration: if duration == auto { none } else { duration },
     // Only the departure from the default travels into the markup. `hidden`
@@ -276,6 +279,85 @@
 /// The last point dims too as soon as the slide has a further step after it,
 /// because then the walk has moved on from it as well. And `stride: 0`, which
 /// puts every point on one step, makes them all dim together on the next.
+/// A group that is revealed in whatever order it is called out.
+///
+/// For points that have no order of their own: what the class names gets
+/// shown, in the order it comes rather than the order it stands in. The digits
+/// `1` to `9` choose; the speaker view shows which digit belongs to which
+/// point.
+///
+/// ```typ
+/// #adaptiv("ablesen", start: 2)[
+///   - positive und negative Werte
+///   - tiefster und höchster Wert
+///   - Abnahme und Zunahme
+/// ]
+/// ```
+///
+/// The group owns as many steps as it has points, and the order changes
+/// nothing about that. Everything that hangs on the step count -- the progress
+/// bar, `info().step.total`, the overflow check, the handout -- is therefore
+/// untouched.
+///
+/// Set, the list keeps its reading order: a point not yet named holds its
+/// place, so nothing jumps when it arrives later.
+#let adaptiv(name, ..items, start: auto, spacing: 0.65em) = context {
+  assert(type(name) == str and name != "", message:
+    "typstage: adaptiv() wants a name as its first argument, so that "
+    + "adaptiv-schicht() can point at the same group.")
+  assert(items.named().len() == 0, message:
+    "typstage: adaptiv() does not know "
+    + items.named().keys().join(", ") + ". It takes start and spacing.")
+  assert(im-fit.get() == 0, message: fit-meldung("adaptiv"))
+  let gegeben = items.pos()
+  assert(gegeben.len() > 0, message: "typstage: adaptiv() wants something to reveal")
+  // A single piece can be a list: then its items are the points. The same
+  // unwrapping as in `stagger` -- a body is rarely the list itself, usually a
+  // sequence in which it stands beside whitespace.
+  let punkte = if gegeben.len() == 1 {
+    let body = gegeben.first()
+    let teile = if body.has("children") { body.children } else { (body,) }
+    teile.filter(c => c.func() in (list.item, enum.item))
+  } else { () }
+  let stuecke = if punkte.len() > 0 { punkte.map(p => p.body) } else { gegeben }
+  let ab = if start == auto { step-cursor.get().first() } else { start }
+  // Recorded so that `adaptiv-schicht` finds the steps again.
+  adaptiv-gruppen.update(g => g + ((name): (start: ab, anzahl: stuecke.len())))
+  for (i, b) in stuecke.enumerate() {
+    if i > 0 { v(spacing, weak: true) }
+    block(anim-kern(
+      if punkte.len() > 0 { list(b) } else { b },
+      at: str(ab + i) + "-", ad: name, ad-nr: i + 1))
+  }
+}
+
+/// Something that appears together with one point of an adaptive group.
+///
+/// A drawing layer, a picture, a sentence beside it: it shares the step with
+/// its point and therefore travels with it, without having to be linked.
+///
+/// ```typ
+/// #adaptiv-schicht("ablesen", 1, schicht-vorzeichen)
+/// ```
+///
+/// The group has to stand *before* its layers in the source, because a layer
+/// looks up which step its point was given. Standing after them, the package
+/// says so rather than quietly doing nothing.
+#let adaptiv-schicht(name, nr, body, enter: "fade") = context {
+  let g = adaptiv-gruppen.get()
+  assert(name in g, message:
+    "typstage: adaptiv-schicht(\"" + name + "\") finds no group of that name. "
+    + "An adaptiv() group has to stand before its layers in the source, "
+    + "because a layer looks up which step its point was given.")
+  let e = g.at(name)
+  assert(nr >= 1 and nr <= e.anzahl, message:
+    "typstage: adaptiv-schicht(\"" + name + "\", " + str(nr) + ") -- that "
+    + "group has " + str(e.anzahl) + " point"
+    + (if e.anzahl == 1 { "" } else { "s" }) + ", so the number is out of range.")
+  anim-kern(body, at: str(e.start + nr - 1) + "-", ad: name, ad-nr: nr,
+            enter: enter)
+}
+
 #let stagger(
   ..items,
   start: auto,

--- a/src/internal.typ
+++ b/src/internal.typ
@@ -147,6 +147,14 @@
 /// All morphs of the document: each entry is slide, name and whether it
 /// stands from step one. Checked at the end: a delayed morph must not share
 /// its name with one on the slide before it, or the flight there is lost.
+/// The adaptive groups of a slide: name -> (start, count).
+///
+/// `adaptiv` records which steps its points were given; `adaptiv-schicht`
+/// looks it up so that it shares one. The coupling then falls out of the
+/// shared step -- swapping the step moves the point and everything tied to it
+/// at once, and nothing has to be linked by name.
+#let adaptiv-gruppen = state("typstage-adaptiv", (:))
+
 #let morph-index = state("typstage-morphs", ())
 
 /// Every element that asked to rest dimmed: its slide and the last step of

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -28,7 +28,8 @@
   // instead of forking the theme.
   info,
 )
-#import "elements.typ": alternatives, anim, morph, pause, pin, stagger
+#import "elements.typ": (adaptiv, adaptiv-schicht, alternatives, anim, morph,
+                         pause, pin, stagger)
 #import "layout.typ": card, callout, fit, side-by-side, statement, tiles
 #import "media.typ": video, embed, flipbook
 #import "bridge.typ": bridge-job, bridge-targets


### PR DESCRIPTION
Manche Stichpunkte haben keine Ordnung. Was ein Graph zeigt, was an einem Versuch auffällt, welche Rechenwege es gibt — die Klasse nennt das in beliebiger Folge, und ein Deck, das in *seiner* Folge aufdeckt, zwingt die Lehrkraft zu warten oder umzusortieren.

```typ
#adaptiv("ablesen", start: 2)[
  - positive und negative Werte
  - tiefster und höchster Wert
  - Abnahme und Zunahme
]
#adaptiv-schicht("ablesen", 1, schicht-vorzeichen)
```

Die Ziffern `1` bis `9` decken auf, was gerade genannt wurde.

## Die Kopplung braucht keinen Mechanismus

Punkt und Schicht teilen sich einen **Schritt** — wer den Schritt vertauscht, bewegt beide. Man kann an einen Punkt hängen, so viel man will, ohne etwas zu verdrahten. Der Name dient nur dazu, die Gruppe zu finden.

Die Gruppe verbraucht so viele Schritte, wie sie Punkte hat, und die Reihenfolge ändert daran nichts: Fortschritt, `info().step.total`, Überlaufprüfung und Handout bleiben unberührt. Beim Setzen behält die Liste ihre Leserichtung, ein noch ungenannter Punkt hält seinen Platz frei.

## Sprecheransicht

Jeder noch offene Punkt steht blass da, mit seiner Ziffer auf dem Aufzählungspunkt; im Saal ist er unsichtbar. Die Ziffern kommen aus der JS und nicht aus dem CSS — eine Regel dort würde den Satz-Fingerabdruck verschieben, dessen Linux-Wert von hier aus nicht neu aufzunehmen ist.

## Vier Fehler beim Bauen, alle durch Hinsehen gefunden

- `background: currentColor` neben `color: #fff` löst zu genau diesem Weiß auf — die Ziffern waren da, nur weiß auf weiß.
- Als Kind des Sprites erbte die Ziffer dessen Deckkraft von 0,3 und war so blass wie der Text, den sie beschriften soll.
- Der Aufräumschritt lief für jedes Mitglied: der Punkt legte seine Marke an, seine Schicht entfernte sie unmittelbar danach. Der Zähler meldete sechs Marken, im Bild war keine.
- Die Punkte standen anfangs auf ihren natürlichen Schritten und wären beim Weiterblättern von selbst gekommen — genau das Verhalten, das eine adaptive Gruppe ersetzen soll.

## Der Sollstand wächst absichtlich

Das Prüfdeck bekommt eine adaptive Gruppe, sonst prüft sie niemand — 13/21 → 15/26. Die `linux`-Werte von `satz`/`satzBytes` gehörten zum alten Prüfdeck und sind **entfernt**: der Build hier fällt daran um und nennt die neuen. Eine Zahl, die niemand gemessen hat, gehört nicht in einen Sollstand.

## Regression

85 PDF-Seiten bei 120 dpi bytegleich zu `main`, beide Handbücher ohne neue Warnung, Beispielprüfer von 125 auf **129** übersetzte Beispiele bei 0 Fehlern.