### PR TITLE
deck-outline(): wie das Deck geschnitten ist

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -12,8 +12,15 @@ permissions:
   pages: write
   id-token: write
 
+# Deploys nach `main` gehoeren serialisiert -- es gibt nur eine Seite, und der
+# neueste Stand gewinnt. Ein Pull Request braucht dagegen seine eigene Spur:
+# mit einer festen Gruppe verdraengt jeder PR jeden anderen, und was uebrig
+# bleibt, sieht aus wie ein Fehlschlag statt nach einem Abbruch. Zweimal
+# passiert, beide Male eine halbe Stunde Suche.
 concurrency:
-  group: github-pages
+  group: >-
+    ${{ github.event_name == 'push' && 'github-pages'
+        || format('github-pages-{0}', github.ref) }}
   cancel-in-progress: true
 
 jobs:

--- a/docs/content-en.typ
+++ b/docs/content-en.typ
@@ -3701,6 +3701,45 @@ The traps, in roughly the order they are usually hit.
 / The speaker view does not open: `window.open` needs a real keypress, and a
   script cannot stand in for the gesture.
 
+=== `deck-outline()`: how the deck is cut
+
+`info()` says *where* you stand. It does not say how the whole thing is
+divided -- and anyone building a navigation bar needs exactly that: which
+slides belong to which section. `deck-outline()` hands it over, one entry per
+section, in the order they come:
+
+// check: folie
+#show-code[```typ
+#context for a in deck-outline() [
+  - #a.number. #a.title -- slides #a.first to #a.last (#a.count)
+]
+```]
+
+On a deck with `slide-level: 3` and two parts of two sub-sections each, the
+first part covers slides 1 to 3, its two sub-sections 1 to 2 and 3 to 3, and
+the second part 4 to 7.
+
+`first`, `last` and `count` are **transitive**: a depth-1 section counts the
+slides of its sub-sections too. A bar that counted only the immediate ones
+would show a zero for every top-level heading. A section with nothing under it
+has `none` for `first` and `last`, and `0` for `count`.
+
+#info[
+  It reads only what every slide already carries -- no `query`, no second walk
+  over the document, the same answer in both outputs. Measured: `tour`,
+  `theme-editorial` and `geogebra` are byte-identical with and without this
+  call, in HTML as in PDF.
+]
+
+#warning[
+  A foreign package looking for the structure through `query(heading)` finds
+  nothing: the heading notation splits the body at its headings and copies
+  `depth` and `body` out, dropping the element itself. That holds in *both*
+  outputs, not only in the browser. `deck-outline()` is the answer to it --
+  the same information, without anyone having to search a document that is not
+  built that way.
+]
+
 = API reference
 
 Generated from the comments in the source files. The order follows the build of

--- a/docs/content.typ
+++ b/docs/content.typ
@@ -4591,6 +4591,46 @@ statt sie zu ersetzen.
 ]
 
 
+=== `deck-outline()`: wie das Deck geschnitten ist
+
+`info()` sagt, *wo* man steht. Es sagt nicht, wie das Ganze gegliedert ist --
+und wer sich eine Navigationsleiste baut, braucht genau das: welche Folien zu
+welchem Abschnitt gehören. `deck-outline()` gibt es heraus, einen Eintrag je
+Abschnitt, in der Reihenfolge, in der sie kommen:
+
+// check: folie
+#show-code[```typ
+#context for a in deck-outline() [
+  - #a.number. #a.title -- Folien #a.first bis #a.last (#a.count)
+]
+```]
+
+An einem Deck mit `slide-level: 3` und zwei Teilen zu je zwei Unterabschnitten
+kommt heraus: der erste Teil deckt die Folien 1 bis 3, seine beiden
+Unterabschnitte 1 bis 2 und 3 bis 3, der zweite Teil 4 bis 7.
+
+`first`, `last` und `count` zählen **transitiv**: unter einen Abschnitt der
+Tiefe 1 fallen auch die Folien seiner Unterabschnitte. Eine Leiste, die nur
+die unmittelbar eigenen zählte, zeigte für jede Oberüberschrift eine Null. Ein
+Abschnitt ohne Folien unter sich hat `none` bei `first` und `last` und `0` bei
+`count`.
+
+#info[
+  Gelesen wird nur, was jede Folie ohnehin mit sich trägt -- kein `query`, kein
+  zweiter Gang durch das Dokument, dieselbe Antwort in beiden Ausgaben.
+  Nachgemessen: `tour`, `theme-editorial` und `geogebra` sind mit und ohne
+  diesen Aufruf byteidentisch, in HTML wie im PDF.
+]
+
+#warning[
+  Ein fremdes Paket, das die Gliederung über `query(heading)` sucht, findet
+  nichts: die Überschriftennotation zerlegt den Rumpf an seinen Überschriften
+  und kopiert `depth` und `body` heraus, das Element selbst fällt weg. Das gilt
+  in *beiden* Ausgaben, nicht nur im Browser. `deck-outline()` ist die Antwort
+  darauf -- dieselbe Auskunft, ohne dass jemand ein Dokument durchsuchen muss,
+  das so nicht gebaut ist.
+]
+
 = API-Referenz
 
 Erzeugt aus den Kommentaren der Quelldateien. Die Reihenfolge folgt dem Aufbau

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -25,8 +25,9 @@
   // One slide in the palette turned around, for the heading notation.
   invert,
   // What the deck knows about itself, so a deck can build its own chrome
-  // instead of forking the theme.
-  info,
+  // instead of forking the theme. `info` says where it stands,
+  // `deck-outline` how the whole thing is cut.
+  info, deck-outline,
 )
 #import "elements.typ": (alternatives, anim, build, camera, cue, cue-layer,
                          morph, pause, pin, scene, scene-layer, stagger)

--- a/src/present.typ
+++ b/src/present.typ
@@ -534,6 +534,59 @@
   let gliederung = abschnitte.enumerate().map(((j, a)) => (
     depth: a.depth, number: ebenen-satz.at(j).number, title: a.title,
   ))
+  // Dasselbe noch einmal, aber mit dem Stück Deck, das zu jedem Abschnitt
+  // gehört. `gliederung` sagt, wie das Deck gegliedert ist; das hier sagt, wo
+  // die Schnitte liegen -- und das ist, was eine Navigationsleiste braucht und
+  // was `info()` bisher schuldig blieb. Wer es nachbauen wollte, müsste an
+  // `state("typstage-info")` heran, also an ein Internum.
+  //
+  // Gezählt wird transitiv: unter einen Abschnitt der Tiefe 1 fallen auch die
+  // Folien seiner Unterabschnitte. Eine Leiste, die nur die eigenen zählte,
+  // zeigte für jede Oberüberschrift eine Null.
+  //
+  // Eine reine Rechnung über `all`, ohne `query` und ohne zweiten Gang durch
+  // das Dokument -- sie zeichnet nichts und kann deshalb auch nichts
+  // verschieben.
+  let schnitte = {
+    let raus = ()
+    let k = 0
+    for (i, s) in all.enumerate() {
+      if s.kind != "section" { continue }
+      let tiefe = abschnitte.at(k).depth
+      let erste = none
+      let letzte = none
+      let wieviele = 0
+      let n = 0
+      let m = 0
+      // Die Folien vor diesem Abschnitt zählen, um bei seiner ersten die
+      // richtige Nummer zu haben.
+      for (j, t) in all.enumerate() {
+        if j >= i { break }
+        if t.kind == "slide" { n += 1 }
+      }
+      let tieferK = k
+      for (j, t) in all.enumerate() {
+        if j <= i { continue }
+        // Ein Abschnitt derselben oder einer flacheren Tiefe beendet den Lauf.
+        if t.kind == "section" {
+          tieferK += 1
+          if abschnitte.at(tieferK).depth <= tiefe { break }
+          continue
+        }
+        if t.kind == "slide" {
+          m += 1
+          wieviele += 1
+          if erste == none { erste = n + m }
+          letzte = n + m
+        }
+      }
+      raus.push((depth: tiefe, number: ebenen-satz.at(k).number,
+                 title: abschnitte.at(k).title,
+                 first: erste, last: letzte, count: wieviele))
+      k += 1
+    }
+    raus
+  }
   // What a section slide hands its theme: its depth, and the titles above it.
   // Both go on the record itself rather than into a new theme key, so a theme
   // that ignores them draws every level alike instead of failing.
@@ -624,6 +677,7 @@
           (number: innen.number, total: innen.total, title: innen.title)
         } else { (number: 0, total: 0, title: none) },
         levels: ebenen,
+        structure: schnitte,
         // `here` marks the one entry that *is* this slide, and only a section
         // slide can be one. Every other slide gets the list built once above.
         outline: if s.kind == "section" {

--- a/src/slides.typ
+++ b/src/slides.typ
@@ -197,6 +197,31 @@
   ))
 }
 
+/// How the deck is cut, section by section.
+///
+/// `info()` says where you are; this says how the whole thing is divided. One
+/// entry per section, in the order they come, each with the slides beneath it:
+///
+/// ```typ
+/// #context for a in deck-outline() {
+///   [#a.number. #a.title -- slides #a.first to #a.last (#a.count)]
+/// }
+/// ```
+///
+/// `first`, `last` and `count` are transitive: a depth-1 section counts the
+/// slides of its sub-sections too. A section with no slides under it has
+/// `none` for `first` and `last`, and 0 for `count`.
+///
+/// Read straight off the state every slide already carries. No `query`, no
+/// second walk over the document, and the same answer in both outputs.
+#let deck-outline() = {
+  let stand = deck-info.get()
+  assert(stand != none, message:
+    "typstage: deck-outline() reads how the deck is cut and therefore works "
+    + "only inside a presentation.")
+  stand.data.at("structure", default: ())
+}
+
 /// A note for the presenter view (key `s`).
 ///
 /// The note has to carry text: the presenter view transports it as a string,


### PR DESCRIPTION
`info()` sagt, *wo* man steht. Es sagt nicht, wie das Ganze gegliedert ist — und
wer sich eine Navigationsleiste baut, braucht genau das.

```typ
#context for a in deck-outline() [
  - #a.number. #a.title -- Folien #a.first bis #a.last (#a.count)
]
```

Ein Eintrag je Abschnitt, in der Reihenfolge, in der sie kommen. `first`, `last`
und `count` zählen **transitiv**: unter einen Abschnitt der Tiefe 1 fallen auch
die Folien seiner Unterabschnitte — eine Leiste, die nur die unmittelbar eigenen
zählte, zeigte für jede Oberüberschrift eine Null.

## Warum

Der Autor des Pakets **navigator** hat gemeldet, dass er über typstage keine
Übergangsfolien erzeugen kann. Nachgemessen: `query(heading)` liefert in einem
typstage-Deck null — **in beiden Ausgaben**, nicht nur im Browser. Die
Überschriftennotation zerlegt den Rumpf an seinen Überschriften und kopiert
`depth` und `body` heraus; das Element fällt weg.

Die naheliegende Abhilfe — versteckte auffindbare Überschriften — wurde
simuliert und **verworfen**: navigator ordnet nach `(page, position.y)`, und
unter HTML-Export ist beides konstant. Es zeigte danach auf *jeder* Folie den
letzten Abschnitt des Decks an, ohne Fehler und ohne Warnung. Still falsch ist
schlechter als sichtbar leer.

`deck-outline()` gibt dieselbe Auskunft direkt, ohne dass jemand ein Dokument
durchsuchen muss, das so nicht gebaut ist.

## Geprüft

Es liest nur Zustand, den jede Folie ohnehin trägt — kein `query`, kein zweiter
Gang durch das Dokument, dieselbe Antwort in beiden Ausgaben.

- `tour`, `theme-editorial` und `geogebra` sind mit und ohne diesen Aufruf
  **byteidentisch**, in HTML wie im PDF
- 197 Handbuchbeispiele · 15 Gegenproben · 0 Fehler
- Handbuchabsatz in beiden Sprachen