### PR TITLE
Wer über dem Ziel eines Fluges steht, bleibt auch während des Fluges darüber

### DIFF
--- a/.github/scripts/decklauf/flug-hoehe.js
+++ b/.github/scripts/decklauf/flug-hoehe.js
@@ -1,0 +1,254 @@
+// =============================================================================
+// flug-hoehe.js — was während eines Fluges übereinander liegt
+// =============================================================================
+// Warum eigens: der große Prüflauf misst Decks im *Ruhezustand*. Er fährt sie
+// durch, wartet nach jedem Schritt, bis nichts mehr läuft, und liest dann ab.
+// Was während der Bewegung übereinander liegt, sieht er nie -- und genau dort
+// saß der Fehler, der das hier ausgelöst hat:
+//
+//   Auf `mosaic-greyscale` fliegt eine Kachel auf die nächste Folie und wird
+//   dort zur ganzen Fläche. Unten rechts steht eine Bildunterschrift, die im
+//   Ruhezustand über dem Bild liegt. Während des Fluges verschwand sie und kam
+//   erst wieder, als das Bild stand. Grund: der Geist hängt auf `#ts-fly`
+//   (z-index 5), sie hängt in der Folie -- zwei getrennte Stapelkontexte,
+//   zwischen die kein z-index passt.
+//
+// Gemessen wird mit angehaltenen Animationen: jede `animate()`-Anfrage wird
+// beim Auslösen sofort pausiert und danach auf feste Bruchteile des Fluges
+// gestellt. So hängt keine Messung an einem Zeitgeber, und der Lauf ist auf
+// einer langsamen Maschine derselbe wie auf einer schnellen.
+//
+// Treffertests brauchen dafür `pointer-events`, die die Flugebene sonst nicht
+// hat. Das Prüfblatt setzt sie; gemalt wird dadurch nichts anders, die
+// Stapelreihenfolge ist dieselbe.
+//
+//   node .github/scripts/decklauf/flug-hoehe.js [--browser /pfad]
+// =============================================================================
+const fs = require("fs"), path = require("path"), os = require("os");
+const { execFileSync } = require("child_process");
+const { starte, schlaf } = require("./cdp.js");
+
+const WURZEL = path.resolve(__dirname, "..", "..", "..");
+const arg = (n, v) => { const i = process.argv.indexOf(n); return i > 0 ? process.argv[i + 1] : v; };
+
+function browserSuchen() {
+  const k = ["/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+             "/Applications/Chromium.app/Contents/MacOS/Chromium",
+             "/usr/bin/google-chrome", "/usr/bin/google-chrome-stable",
+             "/usr/bin/chromium", "/usr/bin/chromium-browser", "/snap/bin/chromium"];
+  const da = k.find(x => fs.existsSync(x));
+  if (!da) { console.error("FEHLER: kein Chrome gefunden, --browser angeben."); process.exit(2); }
+  return da;
+}
+
+function deckBauen() {
+  const pp = fs.mkdtempSync(path.join(os.tmpdir(), "typstage-fh-"));
+  const ziel = path.join(pp, "schule", "typstage");
+  fs.mkdirSync(ziel, { recursive: true });
+  fs.symlinkSync(WURZEL, path.join(ziel, "0.1.0"), "dir");
+  const aus = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "typstage-fh-h-")), "flugdeck.html");
+  execFileSync("typst", ["compile", "--format", "html", "--features", "html",
+    "--root", WURZEL, "--package-path", pp,
+    path.join(__dirname, "flugdeck.typ"), aus], { stdio: ["ignore", "ignore", "pipe"] });
+  return aus;
+}
+
+// Die drei Sprites der zweiten Folie, in Quellreihenfolge: UNTEN, der `morph`,
+// OBEN. Gemerkt wird *vor* dem Tastendruck -- was der Flug hochzieht, hängt
+// danach nicht mehr unter seiner Folie und wäre dort nicht mehr zu finden.
+const MERKEN = `(() => {
+  const st = document.createElement('style');
+  st.textContent = '#ts-fly *,.ts-el,.ts-el *{pointer-events:auto!important}';
+  document.head.appendChild(st);
+  // Die letzte Folie: das Deck stellt eine Titelfolie voran, gezaehlt wird
+  // also nicht ab dem, was in der Quelle zuerst steht.
+  const alle = document.querySelectorAll('.ts-slide');
+  const f = alle[alle.length - 1];
+  const ov = f.querySelector('.ts-ov');
+  const el = [...ov.querySelectorAll('.ts-el')];
+  window.__fh = { ov: ov, unten: el[0], morph: el[1], oben: el[2], fern: el[3],
+                  fly: document.getElementById('ts-fly') };
+  return JSON.stringify({
+    anzahl: el.length,
+    zweitesIstMorph: !!(el[1] && el[1].classList.contains('ts-morph')),
+    andereKeinMorph: [0, 2, 3].every(i => el[i] && !el[i].classList.contains('ts-morph'))
+  });
+})()`;
+
+// Einfrieren und an feste Punkte des Fluges stellen. Gibt für jeden Punkt
+// zurück, wer an der Mitte von OBEN und von UNTEN ganz oben liegt.
+const FRIEREN = `(() => {
+  const h = window.__fh;
+  const orig = Element.prototype.animate; const anims = [];
+  Element.prototype.animate = function (...a) {
+    const an = orig.apply(this, a); anims.push(an); try { an.pause(); } catch (e) {}
+    return an;
+  };
+  // Auch die Aufräum-Zeitgeber: sonst ist der Geist fort, ehe gemessen wird.
+  const oT = window.setTimeout; window.setTimeout = function () { return 0; };
+  document.dispatchEvent(new KeyboardEvent('keydown',
+    { key: 'ArrowRight', bubbles: true, cancelable: true }));
+  window.__fhAus = () => { Element.prototype.animate = orig; window.setTimeout = oT; };
+  const wer = (el) => {
+    const r = el.getBoundingClientRect();
+    const t = document.elementFromPoint(r.x + r.width / 2, r.y + r.height / 2);
+    if (!t) return 'nichts';
+    if (t === el || el.contains(t)) return 'selbst';
+    if (t.closest('#ts-fly')) return 'geist';
+    return 'anderes';
+  };
+  // Steht in diesem Augenblick ueberhaupt ein Geist ueber der Mitte des
+  // Elements? Der Geist waechst von der Kachel zur ganzen Flaeche; ehe er
+  // unten links angekommen ist, sagt ein Treffertest dort nichts ueber die
+  // Hoehe aus.
+  const gedeckt = (el) => {
+    const r = el.getBoundingClientRect();
+    const x = r.x + r.width / 2, y = r.y + r.height / 2;
+    return [...h.fly.querySelectorAll('.ts-ghost')].some(g => {
+      const q = g.getBoundingClientRect();
+      return x >= q.left && x <= q.right && y >= q.top && y <= q.bottom;
+    });
+  };
+  const bahn = (f) => {
+    anims.forEach(an => { const t = an.effect && an.effect.getTiming(); if (!t) return;
+      try { an.currentTime = (t.delay || 0) + (t.duration || 0) * f; } catch (e) {} });
+    return { f: f, oben: wer(h.oben), unten: wer(h.unten),
+             obenGedeckt: gedeckt(h.oben), untenGedeckt: gedeckt(h.unten),
+             fernGedeckt: gedeckt(h.fern), fernOben: h.fern.parentElement === h.fly };
+  };
+  return JSON.stringify([0.25, 0.5, 0.75, 1].map(bahn));
+})()`;
+
+// Wo die drei nach dem Flug hängen, und in welcher Reihenfolge.
+const RUHE = `(() => {
+  const h = window.__fh;
+  const el = [...h.ov.querySelectorAll('.ts-el')];
+  return JSON.stringify({
+    obenInFolie: h.oben.parentElement === h.ov,
+    untenInFolie: h.unten.parentElement === h.ov,
+    reihenfolge: [h.unten, h.morph, h.oben, h.fern].map(x => el.indexOf(x)).join('/'),
+    geisterUebrig: h.fly.children.length
+  });
+})()`;
+
+// Das Verhältnis von OBEN zur Bühne. Ändert sich das Fenster während des
+// Fluges, muss der Hochgezogene mitwandern -- er gehört weiter zu seiner Folie,
+// auch wenn er gerade nicht unter ihr hängt.
+const VERHAELTNIS = `(() => {
+  const h = window.__fh;
+  const b = document.getElementById('ts-stage').getBoundingClientRect();
+  const r = h.oben.getBoundingClientRect();
+  return JSON.stringify({ x: (r.x - b.x) / b.width, y: (r.y - b.y) / b.height,
+                          w: r.width / b.width,
+                          buehne: Math.round(b.width) + "x" + Math.round(b.height) });
+})()`;
+
+(async () => {
+  const datei = deckBauen();
+  const c = await starte(arg("--browser", browserSuchen()));
+  let maengel = [];
+  const sagt = (b, s) => { console.error("ABWEICHUNG " + b + ": " + s); maengel.push(s); };
+  const laden = async () => {
+    await c.navigiere("file://" + datei);
+    await schlaf(1500);
+    // Auf den Schritt vor der letzten Folie: erst der naechste Tastendruck
+    // loest den Flug aus. Das Deck stellt eine Titelfolie voran, ein festes
+    // "#1" traefe also den Wechsel davor.
+    await c.ev("typstage.goto(typstage.steps.length - 2, true)");
+    await schlaf(600);
+  };
+
+  try {
+    // ── 1 Die Stellung selbst ────────────────────────────────────────────────
+    await laden();
+    const bau = JSON.parse(await c.ev(MERKEN));
+    if (bau.anzahl !== 4 || !bau.zweitesIstMorph || !bau.andereKeinMorph) {
+      sagt("deck", "flugdeck.typ trägt nicht mehr die Stellung, die hier geprüft "
+        + "wird: erwartet UNTEN, morph, OBEN, FERN, gefunden " + JSON.stringify(bau)
+        + ". Ohne sie prüft dieser Lauf nichts.");
+      throw new Error("Prüfling passt nicht");
+    }
+
+    // ── 2 Wer liegt während des Fluges oben ──────────────────────────────────
+    const punkte = JSON.parse(await c.ev(FRIEREN));
+    for (const p of punkte) {
+      if (!p.obenGedeckt && p.f >= 0.75) {
+        sagt("deck", "bei " + Math.round(p.f * 100) + "% des Fluges deckt kein Geist "
+          + "die Mitte von OBEN. Dann prüft dieser Lauf die Höhe nicht mehr -- "
+          + "flugdeck.typ muss die beiden so stellen, dass die Bahn sie trifft.");
+      }
+      if (p.fernOben) {
+        sagt("bahn", "bei " + Math.round(p.f * 100) + "% des Fluges hängt FERN in "
+          + "der Flugebene. Es liegt außerhalb der Bahn, der Flug hat es nie "
+          + "verdeckt -- hochgezogen erscheint es vor seiner eigenen Folie.");
+      }
+      if (p.fernGedeckt) {
+        sagt("deck", "FERN liegt in der Bahn des Fluges. Dann prüft dieser Lauf "
+          + "nicht mehr, dass nur Verdecktes hochgezogen wird -- flugdeck.typ muss "
+          + "es außerhalb stellen.");
+      }
+      if (p.oben !== "selbst") {
+        sagt("hoehe", "bei " + Math.round(p.f * 100) + "% des Fluges liegt über OBEN "
+          + "nicht OBEN, sondern " + p.oben + ". Ein Element, das im Ruhezustand "
+          + "über dem Ziel steht, verschwindet also, solange geflogen wird.");
+      }
+      if (p.untenGedeckt && p.unten !== "geist") {
+        sagt("hoehe", "bei " + Math.round(p.f * 100) + "% des Fluges steht ein Geist "
+          + "über UNTEN, oben liegt aber " + p.unten + ". UNTEN steht vor dem `morph` "
+          + "und gehört darunter -- der Flug zieht zu viel hoch.");
+      }
+    }
+
+    // ── 3 Wandert der Hochgezogene beim Vergrößern mit ───────────────────────
+    const vorher = JSON.parse(await c.ev(VERHAELTNIS));
+    await c.ruf("Emulation.setDeviceMetricsOverride",
+      { width: 1100, height: 700, deviceScaleFactor: 1, mobile: false });
+    await schlaf(400);
+    const nachher = JSON.parse(await c.ev(VERHAELTNIS));
+    console.log("    Bühne " + vorher.buehne + " → " + nachher.buehne
+      + ", OBEN w " + vorher.w.toFixed(4) + " → " + nachher.w.toFixed(4));
+    await c.ruf("Emulation.clearDeviceMetricsOverride", {});
+    for (const k of ["x", "y", "w"]) {
+      if (Math.abs(vorher[k] - nachher[k]) > 0.01) {
+        sagt("groesse", "das Fenster wurde mitten im Flug kleiner, und OBEN "
+          + "wanderte nicht mit: " + k + " " + vorher[k].toFixed(3) + " → "
+          + nachher[k].toFixed(3) + ". Ort und Maß eines Hochgezogenen stehen in "
+          + "Prozent auf derselben Fläche wie vorher -- stimmt das nicht mehr, "
+          + "trägt die Flugebene nicht dieselbe Geometrie wie die Folie, und der "
+          + "ganze Umzug ist unsicher.");
+      }
+    }
+    await c.ev("window.__fhAus()");
+
+    // ── 4 Kommen beide zurück ────────────────────────────────────────────────
+    const zurueck = async (titel, schritte) => {
+      await laden();
+      await c.ev(MERKEN);
+      for (const [t, w] of schritte) { await c.taste(t); await schlaf(w); }
+      await schlaf(1400);
+      const r = JSON.parse(await c.ev(RUHE));
+      if (!r.obenInFolie || !r.untenInFolie) {
+        sagt("rueckkehr", titel + ": ein Sprite hängt nach dem Flug nicht wieder "
+          + "unter seiner Folie (OBEN " + r.obenInFolie + ", UNTEN " + r.untenInFolie
+          + "). Es liegt dann über allem, was noch kommt.");
+      }
+      if (r.reihenfolge !== "0/1/2/3") {
+        sagt("rueckkehr", titel + ": die Quellreihenfolge kam als " + r.reihenfolge
+          + " zurück statt als 0/1/2/3.");
+      }
+      if (r.geisterUebrig !== 0) {
+        sagt("rueckkehr", titel + ": " + r.geisterUebrig + " Knoten blieben in der "
+          + "Flugebene liegen.");
+      }
+    };
+    await zurueck("Flug ausgelaufen", [["ArrowRight", 1500]]);
+    await zurueck("mitten im Flug weiter", [["ArrowRight", 200], ["ArrowRight", 900]]);
+    await zurueck("mitten im Flug zurück", [["ArrowRight", 200], ["ArrowLeft", 900]]);
+  } catch (e) {
+    if (!maengel.length) sagt("lauf", e.message);
+  } finally {
+    await c.ende();
+  }
+  console.log("\nFlughöhe: " + (maengel.length ? maengel.length + " Abweichungen" : "ohne Abweichung"));
+  process.exit(maengel.length ? 1 : 0);
+})();

--- a/.github/scripts/decklauf/flugdeck.typ
+++ b/.github/scripts/decklauf/flugdeck.typ
@@ -1,0 +1,66 @@
+// Flugdeck: zwei Folien, ein `morph` und zwei Nachbarn.
+//
+//     typst compile --features html --format html flugdeck.typ flugdeck.html
+//
+// Wozu ein eigenes Deck: `flug-hoehe.js` prüft, was während eines Fluges
+// übereinander liegt, und dafür braucht es eine Stelle, an der genau das
+// entschieden werden muss — ein Element, das im Ruhezustand über dem Ziel des
+// Fluges steht, und eines, das darunter steht. Das Prüfdeck nebenan hat diese
+// Stellung nicht, und sie ihm anzubauen bewegte seinen ganzen Sollstand.
+//
+// Wer hier etwas ändert, ändert eine Messung. Die drei Rechtecke auf der
+// zweiten Folie sind keine Gestaltung: `unten` steht in Quellreihenfolge vor
+// dem `morph` und gehört unter den Geist, `oben` steht danach und gehört
+// darüber, und beide überlappen die Bahn des Fluges. Ohne diese Überlappung
+// prüfte der Lauf nichts.
+
+#import "@schule/typstage:0.1.0": *
+
+#presentation(
+  title: [Flugdeck],
+  author: [typstage #runtime-version],
+  theme: themes.plain,
+  margin: 0pt,
+  // Ein Kreuzblenden, damit die abtretende Folie den Blick auf die neue nicht
+  // durch eine Bewegung ersetzt: geprüft wird die Höhe, nicht der Übergang.
+  transition: "fade",
+  transition-duration: 440,
+  duration: 520,
+
+  // ── 1 Die Kachel ─────────────────────────────────────────────────────────
+  slide(none)[
+    #block(width: 100%, height: 100%, {
+      place(top + left, dx: 60pt, dy: 50pt,
+            morph(<tafel>, block(width: 150pt, height: 100pt, fill: luma(60)),
+                  match: "block"))
+    })
+  ],
+
+  // ── 2 Die Tafel, mit drei Nachbarn ───────────────────────────────────────
+  // Die Tafel nimmt zwei Drittel der Breite. Das ist der Grund für das
+  // Verhältnis: die Bahn des Fluges ist damit *nicht* die ganze Folie, und
+  // rechts daneben ist Platz für einen Nachbarn, den der Flug nie berührt.
+  slide(none)[
+    #block(width: 100%, height: 100%, {
+      // Vor dem `morph`: liegt auch im Ruhezustand darunter. Ein Flug, der
+      // dieses hier mit hochzöge, zöge zu viel.
+      place(top + left, dx: 40pt, dy: 150pt,
+            anim(at: "1-", block(width: 190pt, height: 40pt, fill: blue,
+                                 inset: 10pt)[UNTEN]))
+      place(top + left, morph(<tafel>, block(width: 66%, height: 100%,
+                                             fill: luma(60)), match: "block"))
+      // Nach dem `morph` und in seiner Bahn: liegt darüber. Genau dieses hier
+      // muss den Flug überdauern, ohne dahinter zu verschwinden.
+      place(bottom + left, dx: 40pt, dy: -40pt,
+            anim(at: "1-", block(width: 190pt, height: 40pt, fill: red,
+                                 inset: 10pt)[OBEN]))
+      // Nach dem `morph`, aber außerhalb seiner Bahn. Es liegt im Ruhezustand
+      // ebenfalls darüber -- nur hat der Flug es nie verdeckt, und darum hat
+      // er es auch nicht anzufassen. Wer es trotzdem hochzieht, lässt es einen
+      // Lidschlag früher erscheinen als die Folie, zu der es gehört.
+      place(top + right, dx: -30pt, dy: 40pt,
+            anim(at: "1-", block(width: 150pt, height: 40pt, fill: green,
+                                 inset: 10pt)[FERN]))
+    })
+  ],
+)

--- a/.github/workflows/decks.yml
+++ b/.github/workflows/decks.yml
@@ -75,6 +75,12 @@ jobs:
       - name: Die Fernsteuerung mit zwei Fenstern
         run: node .github/scripts/decklauf/zwei-fenster.js
 
+      # Was während einer Bewegung übereinander liegt. Der Lauf darüber misst
+      # Decks im Ruhezustand -- er wartet nach jedem Schritt, bis nichts mehr
+      # läuft. Die Höhe eines fliegenden Elements sieht er nie.
+      - name: Was während eines Fluges übereinander liegt
+        run: node .github/scripts/decklauf/flug-hoehe.js
+
       - name: Bericht aufheben
         if: always()
         uses: actions/upload-artifact@v4

--- a/assets/typstage-0.1.0.js
+++ b/assets/typstage-0.1.0.js
@@ -1262,6 +1262,69 @@
   var CHROME = [].slice.call(document.querySelectorAll("#ts-chrome > .ts-chrome"));
 
   var flyTimers = [];
+  // Elemente, die im Ruhezustand ueber dem Ziel eines Fluges stehen. Der Geist
+  // liegt auf `#ts-fly`, sie liegen in der Folie -- zwei getrennte
+  // Stapelkontexte, zwischen die kein z-index passt. Fuer die Dauer des Fluges
+  // ziehen sie deshalb mit auf die Flugebene, hinter die Geister, und danach
+  // an ihren Platz zurueck. `.ts-ov` und `#ts-fly` sind beide `inset:0` auf der
+  // Buehne, die Koordinaten stimmen also weiter, und eine Web-Animation
+  // ueberlebt das Umhaengen.
+  var HOCH = [];          // was gerade oben haengt, mit dem Weg zurueck
+  var HOCH_LAUF = 0;      // welcher Flug es hochgezogen hat
+  var NACHZUEGLER = [];   // was der letzte Flug zum Hochziehen vorgemerkt hat
+  var NACHZUEGLER_DAUER = 0;
+
+  function nachzueglerZurueck() {
+    for (var i = HOCH.length - 1; i >= 0; i--) {
+      var h = HOCH[i];
+      if (h.next && h.next.parentNode === h.parent) h.parent.insertBefore(h.el, h.next);
+      else h.parent.appendChild(h.el);
+    }
+    HOCH = [];
+  }
+
+  // Erst *nach* den Sprites von `goto` gerufen: die Schleife dort sucht ihre
+  // Elemente unter `SLIDES[i]`, und was schon oben haengt, faende sie nicht
+  // mehr -- der Nachzuegler bliebe den ganzen Flug lang auf seinem alten Stand.
+  function nachzueglerHoch() {
+    if (!NACHZUEGLER.length) return;
+    // Ort und Mass bleiben von selbst richtig: `setzen()` schreibt beides in
+    // Prozent, und `#ts-fly` und `.ts-ov` sind dieselbe Flaeche. Ein Fenster,
+    // das sich mitten im Flug aendert, traegt den Hochgezogenen also mit --
+    // `stelle()` muss ihn dafuer nicht suchen. Einzig die Rundung stuende
+    // still, denn die rechnet in Punkten; sie gibt es nur an `video()`, und
+    // ein Video als Nachbar eines `morph` ist bis jetzt nirgends geprueft.
+    //
+    // Die Bewegungen der Geister -- vor dem Anhaengen gelesen, damit die
+    // Nachzuegler nicht mit ihren eigenen darin stehen.
+    var fluege = FLY.getAnimations ? FLY.getAnimations({ subtree: true }) : [];
+    NACHZUEGLER.forEach(function (el) {
+      if (!el.parentNode) return;
+      HOCH.push({ el: el, parent: el.parentNode, next: el.nextSibling });
+      FLY.appendChild(el);
+    });
+    NACHZUEGLER = [];
+
+    // Zurueck, sobald der Flug wirklich zu Ende ist, und nicht erst, wenn ein
+    // Zeitgeber es fuer wahrscheinlich haelt: `finished` faellt als Microtask
+    // an, noch in dem Bild, in dem die letzte Bewegung steht. Ein Zeitgeber
+    // mit derselben Frist kann danach kommen -- gemessen im Decklauf, der
+    // nach jedem Schritt wartet, bis nichts mehr laeuft, und dann eine Folie
+    // vorfand, unter der ein Sprite fehlte (`sichtbar` 3/0·1/0 statt 3/0·2/0).
+    // Der Zeitgeber bleibt als Rueckfall stehen: wo gar nichts animiert wurde,
+    // faellt auch kein `finished` an.
+    var lauf = ++HOCH_LAUF;
+    if (fluege.length) {
+      Promise.all(fluege.map(function (a) {
+        return a.finished.catch(function () {});
+      })).then(function () {
+        if (lauf === HOCH_LAUF) nachzueglerZurueck();
+      });
+    }
+    flyTimers.push(setTimeout(function () {
+      if (lauf === HOCH_LAUF) nachzueglerZurueck();
+    }, NACHZUEGLER_DAUER));
+  }
   // How many ghosts a talk has produced since it was loaded. Counted where
   // they are made, not read off `#ts-fly` afterwards: the layer is emptied
   // again by a timer, so whoever counts it later counts whatever the machine
@@ -1288,6 +1351,8 @@
     // the slide change falls back to the ordinary transition. `false` says
     // "no morph happened", the same answer a slide pair without a matching
     // name gives, and it is the same route a jump already takes.
+    NACHZUEGLER = [];
+    NACHZUEGLER_DAUER = 0;
     if (wenigerBewegung()) return false;
     flyTimers.forEach(function (t) { clearTimeout(t); });
     flyTimers = [];
@@ -1327,6 +1392,27 @@
 
       src.dataset.hold = "1";
       dst.dataset.hold = "1";
+
+      // Die Bahn ist das Rechteck, das der Geist ueberstreicht: von der Quelle
+      // zum Ziel. Vorgemerkt wird nur, was in Quellreihenfolge *nach* dem
+      // `morph` steht -- also im Ruhezustand ohnehin darueber liegt -- und was
+      // diese Bahn beruehrt. Alles andere hat der Flug nie verdeckt.
+      var bahn = {
+        left: Math.min(qr.left, zr.left), top: Math.min(qr.top, zr.top),
+        right: Math.max(qr.right, zr.right), bottom: Math.max(qr.bottom, zr.bottom)
+      };
+      var danach = false;
+      SLIDES[toSlide].querySelectorAll(".ts-el").forEach(function (el) {
+        if (el === dst) { danach = true; return; }
+        if (!danach || el.dataset.hold === "1") return;
+        if (NACHZUEGLER.indexOf(el) >= 0) return;
+        var r = el.getBoundingClientRect();
+        if (r.right <= bahn.left || r.left >= bahn.right ||
+            r.bottom <= bahn.top || r.top >= bahn.bottom) return;
+        NACHZUEGLER.push(el);
+      });
+      if (d > NACHZUEGLER_DAUER) NACHZUEGLER_DAUER = d;
+
       var ghosts = [];
       var ueber = 0.42;
       var window = { duration: d * ueber, delay: d * (0.5 - ueber / 2),
@@ -3366,6 +3452,10 @@
     var back = current > n;
     current = n;
 
+    // Vor allem anderen: was ein Flug hochgezogen hat, gehoert zurueck in
+    // seine Folie, bevor irgendjemand dort wieder Elemente sucht.
+    nachzueglerZurueck();
+
     if (changed) stelle(dst.slide);
 
     var hasMorph = false;
@@ -3467,6 +3557,10 @@
     // invisible to the speaker as well, and there is nothing to choose from
     // in an empty column.
     adSprecher();
+
+    // Ganz zuletzt, nachdem Vorschau, Marken und Sprecheransicht oben noch
+    // einmal unter der Folie gesucht haben.
+    nachzueglerHoch();
   }
 
   // ── Slide transitions ─────────────────────────────────────────────────────

--- a/docs/content-en.typ
+++ b/docs/content-en.typ
@@ -2070,6 +2070,12 @@ per glyph, `"block"` moves the whole thing as one rectangle.
   swarm rather than a movement.
 ]
 
+Whatever stands #emph[above] the flight's destination on the target slide
+stays above it while it flies. Source order decides, at rest and in motion
+alike: what is written after the `morph` lies on top of it, what comes before
+lies below. A caption sitting on the finished picture therefore does not have
+to wait until the picture has landed.
+
 == When the wrong signs fly
 
 Where the pairing goes astray, name the pieces. `pin` marks a piece inside a

--- a/docs/content.typ
+++ b/docs/content.typ
@@ -2825,6 +2825,12 @@ Rechnung, Zeile für Zeile:
   nicht Zwischenschritte einer Rechnung.
 ]
 
+Was auf der Zielfolie #emph[über] dem Ziel des Fluges steht, bleibt auch
+während des Fluges darüber. Die Quellreihenfolge entscheidet, im Stillstand
+wie in der Bewegung: Was nach dem `morph` notiert ist, liegt darüber, was
+davor steht, darunter. Eine Bildunterschrift, die auf dem fertigen Bild sitzt,
+muss also nicht warten, bis das Bild angekommen ist.
+
 == Wenn die Zeichen falsch fliegen: pin
 
 Die Paarung sucht sich zu jedem Zeichen der alten Folie das passende Zeichen


### PR DESCRIPTION
Auf `mosaic-greyscale` fliegt eine Kachel auf die nächste Folie und wird dort zur ganzen Fläche. Unten rechts steht eine Bildunterschrift, die im Ruhezustand über dem Bild liegt. Während des Fluges verschwand sie und kam erst wieder, als das Bild stand.

## Was gemessen wurde

Der Flug lässt sich einfrieren: jede `animate()`-Anfrage beim Auslösen pausieren, danach auf feste Bruchteile stellen. Dann sind es zwei Ursachen, die sich fast genau in der Mitte die Hand reichen.

| | Geist (x/y/b/h) | Folie 9 (alt) | Folie 10 (neu) |
|---|---|---|---|
| 10 % | 277/118/268/142 | Deckkraft 0,97 · z 2 | 1 · z 1 |
| 50 % | 64/105/494/276 | 0,22 · z 2 | 1 · z 1 |
| 100 % | 0/101/562/316 | 0 · z 2 | 1 · z 1 |

Panel: 261/381/278/24.

**Erste Hälfte:** die ausgehende Folie liegt über der neuen. Bei einem Morph erzwingt die Laufzeit `"fade"`, und die neue Folie steht dabei von Anfang an auf voller Deckkraft — sichtbar wird sie nur, weil die alte über ihr verschwindet.

**Zweite Hälfte:** ab etwa 50 % überlappt der Geist das Panel, und `#ts-fly` trägt `z-index:5`.

Ein z-index allein hilft nicht: Panel und Geist sitzen in getrennten Stapelkontexten.

## Was jetzt geschieht

Beim Flug werden die Elemente der Zielfolie vorgemerkt, die in Quellreihenfolge **nach** dem `morph` stehen und seine Bahn — die Vereinigung von Start- und Zielrechteck — berühren. Sie ziehen für die Dauer des Fluges in die Flugebene hinter die Geister und danach an ihren Platz zurück. Ort und Maß bleiben von selbst richtig: `setzen()` schreibt beides in Prozent, und `#ts-fly` und `.ts-ov` sind dieselbe Fläche.

Zwei Feinheiten, beide durch eine Messung erzwungen:

- **Das Hochziehen steht als letzte Anweisung von `goto`.** Vorschau, Marken und Sprecheransicht suchen davor noch einmal unter der Folie; was schon oben hängt, fänden sie nicht.
- **Die Rückkehr hängt an `finished` der Flugbewegungen**, nicht an einem Zeitgeber. Mit dem Zeitgeber allein meldete der Decklauf `mosaic-greyscale.sichtbar` als `3/0·1/0` statt `3/0·2/0`: er wartet nach jedem Schritt, bis nichts mehr läuft, und fand dann eine Folie, unter der ein Sprite fehlte. Der Zeitgeber bleibt als Rückfall stehen.

## Was nicht drin ist

Eine Wache in `stelle()`, die Hochgezogene beim Vermessen mitzählt, war gebaut und ist wieder entfernt: die Mutation dazu fing niemand, und zu Recht — Prozentwerte wandern von selbst mit. Übrig bleibt die Eckenrundung, die in Punkten rechnet; die gibt es nur an `video()`, und ein Video als Nachbar eines `morph` ist nirgends geprüft. Der Grund steht als Kommentar da statt als Code, den keine Prüfung erreicht.

## Prüfung

Neu: `decklauf/flug-hoehe.js` mit eigenem Messdeck `decklauf/flugdeck.typ` — UNTEN vor dem `morph`, OBEN dahinter in der Bahn, FERN dahinter außerhalb. Fährt in der CI mit.

| Mutation | gefangen von |
|---|---|
| gar nicht hochziehen | `hoehe` (4×) |
| unter statt über die Geister hängen | `hoehe` (2×) |
| auch hochziehen, was darunter gehört | `hoehe`, UNTEN |
| nie zurückholen | `rueckkehr` (8×) |
| die Bahn nicht prüfen | `bahn` (4×) |

Beispiele 197/0, Decklauf 16/16 ohne Abweichung, zwei Fenster ohne Abweichung. Kein Sollwert bewegt sich.